### PR TITLE
fix(issue-2): conditionally zero storage-node conduit half-areas

### DIFF
--- a/src/engine/core/SWMMEngine.cpp
+++ b/src/engine/core/SWMMEngine.cpp
@@ -1320,8 +1320,14 @@ void SWMMEngine::stepRouting(double dt_routing) noexcept {
                 sa = links.xsect_a_full[uj] * links.setting[uj];
             }
             double sa1 = sa / 2.0, sa2 = sa / 2.0;
-            if (ctx.nodes.type[un1] == NodeType::STORAGE) sa1 = 0.0;
-            if (ctx.nodes.type[un2] == NodeType::STORAGE) sa2 = 0.0;
+            if (ctx.nodes.type[un1] == NodeType::STORAGE) {
+                double As1 = node::getSurfArea(ctx.nodes, n1, ctx.nodes.depth[un1], &ctx.tables);
+                if (As1 > constants::MIN_SURFAREA) sa1 = 0.0;
+            }
+            if (ctx.nodes.type[un2] == NodeType::STORAGE) {
+                double As2 = node::getSurfArea(ctx.nodes, n2, ctx.nodes.depth[un2], &ctx.tables);
+                if (As2 > constants::MIN_SURFAREA) sa2 = 0.0;
+            }
             dw.nodeState(n1).new_surf_area += sa1;
             dw.nodeState(n2).new_surf_area += sa2;
         }

--- a/src/engine/hydraulics/DynamicWave.cpp
+++ b/src/engine/hydraulics/DynamicWave.cpp
@@ -1406,12 +1406,20 @@ void DWSolver::updateNodeFlows(SimulationContext& ctx, bool conduits_only) {
         xnode_[un1].sumdqdh += dqdh_[uj];
         xnode_[un2].sumdqdh += dqdh_[uj];
 
-        // Zero surface area for STORAGE nodes (matching legacy dynwave.c lines 507-510)
-        // Storage nodes get their surface area from the storage curve, not from links.
+        // Zero conduit half-areas at STORAGE nodes only when the storage curve
+        // already provides a meaningful footprint. If the curve value is at or
+        // below MIN_SURFAREA (degenerate / synthetic storage), keep the legacy
+        // pipe-half contribution so the Picard denominator stays bounded.
         double sa1 = surf_area1_[uj];
         double sa2 = surf_area2_[uj];
-        if (nodes.type[un1] == NodeType::STORAGE) sa1 = 0.0;
-        if (nodes.type[un2] == NodeType::STORAGE) sa2 = 0.0;
+        if (nodes.type[un1] == NodeType::STORAGE) {
+            double As1 = node::getSurfArea(nodes, n1, nodes.depth[un1], &ctx.tables);
+            if (As1 > constants::MIN_SURFAREA) sa1 = 0.0;
+        }
+        if (nodes.type[un2] == NodeType::STORAGE) {
+            double As2 = node::getSurfArea(nodes, n2, nodes.depth[un2], &ctx.tables);
+            if (As2 > constants::MIN_SURFAREA) sa2 = 0.0;
+        }
 
         // Add conduit evap/seepage loss to node outflows (matching legacy lines 542-558)
         if (links.type[uj] == LinkType::CONDUIT) {

--- a/tests/unit/engine/test_gap_fixes.cpp
+++ b/tests/unit/engine/test_gap_fixes.cpp
@@ -1121,3 +1121,110 @@ TEST(HydPower, ConvertToHorsepower) {
     EXPECT_GT(hp, 0.0);
     EXPECT_NEAR(hp, 3120.0 / 550.0, 0.01);
 }
+
+// ===========================================================================
+// Issue 2 — Storage-node conduit half-area guard
+//
+// The fix in DynamicWave::updateNodeFlows and SWMMEngine non-conduit callback
+// zeroes conduit/orifice half-areas at a STORAGE node only when the storage
+// curve provides area > MIN_SURFAREA. When the curve is degenerate (area ==
+// MIN_SURFAREA, i.e. FUNCTIONAL 0 0 0), the pipe half-areas are kept so the
+// Picard denominator stays bounded.
+//
+// These tests verify the precondition the guard relies on: getSurfArea must
+// return > MIN_SURFAREA for a real curve and exactly MIN_SURFAREA for a
+// degenerate one.
+// ===========================================================================
+
+TEST(StorageHalfAreaGuard, RealCurveProvidesArea) {
+    // FUNCTIONAL 1000 0 0 → A(d) = 1000 for all d
+    // getSurfArea should return 1000 > MIN_SURFAREA → guard zeros pipe halves
+    NodeData nodes;
+    nodes.resize(1);
+    nodes.type[0] = NodeType::STORAGE;
+    nodes.full_depth[0] = 10.0;
+    nodes.storage_curve[0] = -1;  // functional
+    nodes.storage_a[0] = 1000.0;
+    nodes.storage_b[0] = 0.0;
+    nodes.storage_c[0] = 0.0;
+
+    double sa = node::getSurfArea(nodes, 0, 5.0);
+    EXPECT_GT(sa, constants::MIN_SURFAREA)
+        << "Real storage curve should exceed MIN_SURFAREA";
+    EXPECT_NEAR(sa, 1000.0, 0.01);
+}
+
+TEST(StorageHalfAreaGuard, DegenerateCurveFloors) {
+    // FUNCTIONAL 0 0 0 → A(d) = 0 for all d → clamped to MIN_SURFAREA
+    // getSurfArea should return exactly MIN_SURFAREA → guard keeps pipe halves
+    NodeData nodes;
+    nodes.resize(1);
+    nodes.type[0] = NodeType::STORAGE;
+    nodes.full_depth[0] = 10.0;
+    nodes.storage_curve[0] = -1;  // functional
+    nodes.storage_a[0] = 0.0;
+    nodes.storage_b[0] = 0.0;
+    nodes.storage_c[0] = 0.0;
+
+    double sa = node::getSurfArea(nodes, 0, 5.0);
+    EXPECT_NEAR(sa, constants::MIN_SURFAREA, 1e-10)
+        << "Degenerate storage curve should return exactly MIN_SURFAREA";
+}
+
+TEST(StorageHalfAreaGuard, SmallCurveBelowThreshold) {
+    // FUNCTIONAL 0 0.01 0 → A(d) = 0.01 for all d → clamped to MIN_SURFAREA
+    // Guard should keep pipe halves for this near-zero curve
+    NodeData nodes;
+    nodes.resize(1);
+    nodes.type[0] = NodeType::STORAGE;
+    nodes.full_depth[0] = 10.0;
+    nodes.storage_curve[0] = -1;
+    nodes.storage_a[0] = 0.01;
+    nodes.storage_b[0] = 0.0;
+    nodes.storage_c[0] = 0.0;
+
+    double sa = node::getSurfArea(nodes, 0, 5.0);
+    EXPECT_NEAR(sa, constants::MIN_SURFAREA, 1e-10)
+        << "Tiny curve (0.01 ft²) should clamp to MIN_SURFAREA";
+}
+
+TEST(StorageHalfAreaGuard, CurveJustAboveThreshold) {
+    // FUNCTIONAL 13 0 0 → A(d) = 13 > MIN_SURFAREA (12.566)
+    // Guard should zero pipe halves
+    NodeData nodes;
+    nodes.resize(1);
+    nodes.type[0] = NodeType::STORAGE;
+    nodes.full_depth[0] = 10.0;
+    nodes.storage_curve[0] = -1;
+    nodes.storage_a[0] = 13.0;
+    nodes.storage_b[0] = 0.0;
+    nodes.storage_c[0] = 0.0;
+
+    double sa = node::getSurfArea(nodes, 0, 5.0);
+    EXPECT_GT(sa, constants::MIN_SURFAREA)
+        << "Curve area 13 ft² should exceed MIN_SURFAREA (12.566 ft²)";
+    EXPECT_NEAR(sa, 13.0, 0.01);
+}
+
+TEST(StorageHalfAreaGuard, DepthDependentCrosses) {
+    // FUNCTIONAL 0 100 1 → A(d) = 100*d
+    // At d=0.1: A = 10 < MIN_SURFAREA → pipe halves kept
+    // At d=5.0: A = 500 > MIN_SURFAREA → pipe halves zeroed
+    NodeData nodes;
+    nodes.resize(1);
+    nodes.type[0] = NodeType::STORAGE;
+    nodes.full_depth[0] = 20.0;
+    nodes.storage_curve[0] = -1;
+    nodes.storage_a[0] = 100.0;
+    nodes.storage_b[0] = 1.0;
+    nodes.storage_c[0] = 0.0;
+
+    double sa_low = node::getSurfArea(nodes, 0, 0.1);
+    EXPECT_NEAR(sa_low, constants::MIN_SURFAREA, 1e-10)
+        << "At shallow depth (A=10), should clamp to MIN_SURFAREA";
+
+    double sa_high = node::getSurfArea(nodes, 0, 5.0);
+    EXPECT_GT(sa_high, constants::MIN_SURFAREA);
+    EXPECT_NEAR(sa_high, 500.0, 0.01)
+        << "At depth 5 (A=500), should return curve value";
+}


### PR DESCRIPTION
Only strip conduit/orifice half-areas at a STORAGE node when the storage curve provides area > MIN_SURFAREA. For degenerate storage nodes (zero or near-zero curve), keep the legacy pipe-half contribution so the Picard denominator stays bounded away from MIN_SURFAREA.

Fixes: DynamicWave.cpp::updateNodeFlows (conduit path)
Fixes: SWMMEngine.cpp non-conduit callback (orifice path)
Tests: 5 new StorageHalfAreaGuard unit tests