### PR TITLE
fix(lid): restore unit conversions + subcatchment/mass-balance coupling (#102)

### DIFF
--- a/src/engine/core/SWMMEngine.cpp
+++ b/src/engine/core/SWMMEngine.cpp
@@ -1374,10 +1374,6 @@ void SWMMEngine::stepRunoff(double dt_routing) noexcept {
         //   lidInflow = (qImperv * fromImperv + qPerv * fromPerv) / lidArea
         // where qImperv/qPerv are CFS from non-LID impervious/pervious subareas.
         const auto& rsoa = runoff_.soa();
-        // Gage rainfall is stored in project rain units (in/hr | mm/hr); the LID
-        // solver runs in internal ft/sec, so convert (issue #102). The subarea
-        // runon terms below are already CFS ÷ ft² = ft/sec.
-        const double RAIN_TO_FTSEC = 1.0 / ucf::UCF(ucf::RAINFALL, ctx_.options);
         for (int t = 0; t < lid_.numGroups(); ++t) {
             auto& g = lid_.group(t);
             if (g.count == 0) continue;
@@ -1389,11 +1385,11 @@ void SWMMEngine::stepRunoff(double dt_routing) noexcept {
                     continue;
                 }
                 auto usc = static_cast<std::size_t>(sc);
-                // Gage rainfall for this subcatchment (in/hr|mm/hr → ft/sec)
-                int gage = ctx_.subcatches.gage[usc];
-                double rain = (gage >= 0)
-                    ? ctx_.gages.rainfall[static_cast<std::size_t>(gage)] * RAIN_TO_FTSEC
-                    : 0.0;
+                // Subcatchment precipitation (ft/sec, internal units) — set by
+                // RunoffSolver from the gage AFTER applying per-subcatchment
+                // rainfall forcing and snowmelt, so the LID sees the same
+                // precip the rest of the subcatchment does (issue #102).
+                double rain = ctx_.subcatches.rainfall[usc];
                 // Per-subarea runoff CFS from non-LID area (set by RunoffSolver, Gap #23)
                 double q_imperv = rsoa.imperv_runoff_cfs[usc];
                 double q_perv   = rsoa.perv_runoff_cfs[usc];

--- a/src/engine/core/SWMMEngine.cpp
+++ b/src/engine/core/SWMMEngine.cpp
@@ -1348,8 +1348,10 @@ void SWMMEngine::stepRunoff(double dt_routing) noexcept {
             }
         }
 
-        // A4b. Accumulate runoff mass balance totals
-        accumulateRunoffMassBalance(dt_runoff);
+        // A4b. Runoff mass-balance accumulation is deferred to A6c (after the
+        // LID routing adjusts subcatches.runoff by −VlidIn/+VlidOut/+drain);
+        // accumulating here would capture the pre-LID runoff and miss the LID
+        // exchange, leaving the continuity unbalanced (issue #102 D/E).
 
         // A4b'. Phase 1b auto-save hook — when the runoff interface file
         // is open in SAVE mode, emit one record per substep. saveResults
@@ -1372,6 +1374,10 @@ void SWMMEngine::stepRunoff(double dt_routing) noexcept {
         //   lidInflow = (qImperv * fromImperv + qPerv * fromPerv) / lidArea
         // where qImperv/qPerv are CFS from non-LID impervious/pervious subareas.
         const auto& rsoa = runoff_.soa();
+        // Gage rainfall is stored in project rain units (in/hr | mm/hr); the LID
+        // solver runs in internal ft/sec, so convert (issue #102). The subarea
+        // runon terms below are already CFS ÷ ft² = ft/sec.
+        const double RAIN_TO_FTSEC = 1.0 / ucf::UCF(ucf::RAINFALL, ctx_.options);
         for (int t = 0; t < lid_.numGroups(); ++t) {
             auto& g = lid_.group(t);
             if (g.count == 0) continue;
@@ -1383,19 +1389,25 @@ void SWMMEngine::stepRunoff(double dt_routing) noexcept {
                     continue;
                 }
                 auto usc = static_cast<std::size_t>(sc);
-                // Gage rainfall for this subcatchment
+                // Gage rainfall for this subcatchment (in/hr|mm/hr → ft/sec)
                 int gage = ctx_.subcatches.gage[usc];
-                double rain = (gage >= 0) ? ctx_.gages.rainfall[static_cast<std::size_t>(gage)] : 0.0;
+                double rain = (gage >= 0)
+                    ? ctx_.gages.rainfall[static_cast<std::size_t>(gage)] * RAIN_TO_FTSEC
+                    : 0.0;
                 // Per-subarea runoff CFS from non-LID area (set by RunoffSolver, Gap #23)
                 double q_imperv = rsoa.imperv_runoff_cfs[usc];
                 double q_perv   = rsoa.perv_runoff_cfs[usc];
                 double lid_area = g.area[uu];
                 // Inflow = rainfall on LID + fraction of non-LID subarea runoff captured
-                double q_from_sc = 0.0;
-                if (lid_area > 0.0)
-                    q_from_sc = (q_imperv * g.from_imperv[uu]
-                               + q_perv   * g.from_perv[uu]) / lid_area;
+                double captured_cfs = q_imperv * g.from_imperv[uu]
+                                    + q_perv   * g.from_perv[uu];
+                double q_from_sc = (lid_area > 0.0) ? captured_cfs / lid_area : 0.0;
                 g.inflow[uu] = rain + q_from_sc;
+                // Remove the captured runon from the subcatchment outlet — that
+                // runoff is now treated by the LID, not discharged. This is the
+                // "− VlidIn" term of legacy subcatch_getRunoff() (#102 D); the
+                // LID's own surface outflow (+ VlidOut) is added back in A6b.
+                ctx_.subcatches.runoff[usc] -= captured_cfs;
             }
         }
 
@@ -1424,24 +1436,25 @@ void SWMMEngine::stepRunoff(double dt_routing) noexcept {
                         g.surface_runoff[uu] * lid_area;  // CFS
                 }
                 // Drain flow (ft/sec * ft² = CFS):
-                //  drain_node >= 0 → external node inflow
-                //  otherwise → runon to target subcatch next step via lid_drain_runon_cfs
-                //  Matches legacy lid_addDrainRunon(): drain goes to runon, not runoff.
+                //  drain_node >= 0        → external node inflow (lid_addDrainInflow)
+                //  drain_subcatch != self → runon to that subcatch (lid_addDrainRunon)
+                //  no target / self       → discharge to THIS subcatchment's outlet
+                //  The no-target case previously recirculated as runon-to-self,
+                //  which double-feeds the subcatchment and leaks continuity;
+                //  EPA sends it straight to the outlet (issue #102 E).
                 if (g.drain_node[uu] >= 0) {
-                    // Route drain to a specific node — add as external inflow
                     auto un = static_cast<std::size_t>(g.drain_node[uu]);
                     if (un < ctx_.nodes.ext_inflow.size()) {
                         ctx_.nodes.ext_inflow[un] += g.drain_flow[uu] * lid_area;  // CFS
                     }
-                } else {
-                    // Route drain as runon to target subcatch next step.
-                    int target_sc = (g.drain_subcatch[uu] >= 0)
-                                    ? g.drain_subcatch[uu] : sc;
-                    auto utsc = static_cast<std::size_t>(target_sc);
+                } else if (g.drain_subcatch[uu] >= 0 && g.drain_subcatch[uu] != sc) {
+                    auto utsc = static_cast<std::size_t>(g.drain_subcatch[uu]);
                     if (utsc < ctx_.subcatches.lid_drain_runon_cfs.size()) {
                         ctx_.subcatches.lid_drain_runon_cfs[utsc] +=
                             g.drain_flow[uu] * lid_area;  // CFS
                     }
+                } else {
+                    ctx_.subcatches.runoff[usc] += g.drain_flow[uu] * lid_area;  // CFS
                 }
 
                 // Gap #26: LID drain quality routing.
@@ -1491,6 +1504,10 @@ void SWMMEngine::stepRunoff(double dt_routing) noexcept {
                 }
             }
         }
+
+        // A6c. Accumulate runoff mass-balance totals now that the LID routing
+        // has finalised subcatches.runoff (moved from A4b — see note there).
+        accumulateRunoffMassBalance(dt_runoff);
 
         // A7. Street sweeping buildup removal (Gap #34)
         // Matches legacy surfqual_sweepBuildup(): per-(subcatch, landuse)
@@ -1767,22 +1784,28 @@ void SWMMEngine::accumulateRunoffMassBalance(double dt_runoff) noexcept {
     // breaking the runoff continuity balance.
     const double LANDAREA_TO_FT2 = 1.0 / ucf::UCF(ucf::LANDAREA, ctx_.options);
 
+    const auto& rsoa = runoff_.soa();
     for (int i = 0; i < ctx_.n_subcatches(); ++i) {
         auto ui = static_cast<std::size_t>(i);
         double area_ft2 = ctx_.subcatches.area[ui] * LANDAREA_TO_FT2;
+        // evap_loss / infil_loss are averaged over the NON-LID area only
+        // (RunoffSolver divides Vevap/Vinfil by soa.area = full − LID area).
+        // Multiplying them by the full subcatchment area double-counts the
+        // loss when LIDs cover part of the subcatchment (issue #102 —
+        // exposed once the LID footprint is actually removed, fix B).
+        double nonlid_area_ft2 = rsoa.area[ui];  // ft²
 
-        // Rainfall volume (ft³) — rainfall is already in ft/sec (internal units)
+        // Rainfall volume (ft³) — falls on the whole subcatchment (incl. LID)
         double rain_ftsec = ctx_.subcatches.rainfall[ui];
         ctx_.mass_balance.runoff_rainfall += rain_ftsec * area_ft2 * dt_runoff;
 
-        // Evaporation volume (ft³) — evap_loss is ft/sec
+        // Evaporation volume (ft³) — evap_loss is a non-LID-area-averaged rate
         ctx_.mass_balance.runoff_evap +=
-            ctx_.subcatches.evap_loss[ui] * area_ft2 * dt_runoff;
+            ctx_.subcatches.evap_loss[ui] * nonlid_area_ft2 * dt_runoff;
 
-        // Infiltration volume (ft³) — infil_loss is area-averaged rate (ft/sec)
-        // Already accounts for pervious fraction (Vinfil / dt / total_area)
+        // Infiltration volume (ft³) — infil_loss is a non-LID-area-averaged rate
         ctx_.mass_balance.runoff_infil +=
-            ctx_.subcatches.infil_loss[ui] * area_ft2 * dt_runoff;
+            ctx_.subcatches.infil_loss[ui] * nonlid_area_ft2 * dt_runoff;
 
         // Surface runoff volume (ft³) — runoff is cfs
         ctx_.mass_balance.runoff_runoff +=
@@ -1796,6 +1819,18 @@ void SWMMEngine::accumulateRunoffMassBalance(double dt_runoff) noexcept {
         ctx_.subcatches.stat_runoff_vol[ui] +=
             ctx_.subcatches.runoff[ui] * dt_runoff;
     }
+
+    // Fold this step's LID exfiltration / evaporation into the runoff-continuity
+    // infil / evap outflow terms (legacy VlidInfil / VlidEvap in subcatch.c).
+    // The LID solver tracks cumulative wb_infil/wb_evap; add the delta since the
+    // previous runoff step. Without this a LID with storage-layer exfiltration
+    // (STORAGE Ksat > 0) loses water that never appears as a continuity outflow.
+    double lid_infil_vol = lid_.totalInfilVolume();
+    double lid_evap_vol  = lid_.totalEvapVolume();
+    ctx_.mass_balance.runoff_infil += (lid_infil_vol - prev_lid_infil_vol_);
+    ctx_.mass_balance.runoff_evap  += (lid_evap_vol  - prev_lid_evap_vol_);
+    prev_lid_infil_vol_ = lid_infil_vol;
+    prev_lid_evap_vol_  = lid_evap_vol;
 }
 
 // ============================================================================
@@ -1918,6 +1953,10 @@ int SWMMEngine::refreshTreatment(int node_idx, int pollut_idx) noexcept {
  */
 void SWMMEngine::refreshLIDDrainParams() noexcept {
     const auto& drain = ctx_.lid_controls.drain;
+    // Mirror the LID init() unit conversions (issue #102): coeff/expon stay in
+    // user units (converted at compute time by getDrainRate); the head-based
+    // columns convert in|mm → ft and the delay converts hours → seconds.
+    const double ucfRainDepth = ucf::UCF(ucf::RAINDEPTH, ctx_.options);
     for (int t = 0; t < lid_.numGroups(); ++t) {
         auto& g = lid_.group(t);
         for (int i = 0; i < g.count; ++i) {
@@ -1927,10 +1966,10 @@ void SWMMEngine::refreshLIDDrainParams() noexcept {
             const auto& p = drain[static_cast<std::size_t>(li)];
             g.drain_coeff[ui]  = p[0];
             g.drain_expon[ui]  = p[1];
-            g.drain_offset[ui] = p[2];
-            g.drain_delay[ui]  = p[3];
-            g.drain_hopen[ui]  = p[4];
-            g.drain_hclose[ui] = p[5];
+            g.drain_offset[ui] = p[2] / ucfRainDepth;
+            g.drain_delay[ui]  = p[3] * 3600.0;
+            g.drain_hopen[ui]  = p[4] / ucfRainDepth;
+            g.drain_hclose[ui] = p[5] / ucfRainDepth;
         }
     }
 }
@@ -3088,7 +3127,16 @@ void SWMMEngine::computeFinalStorage() noexcept {
                  + soa.depth_imperv1[ui] * f1
                  + soa.depth_perv[ui] * fp) * area;
         }
+        // Credit water retained inside LID units — otherwise LID retention
+        // reads as a continuity leak (issue #102 C). Matches legacy
+        // subcatch_getStorage()'s + lid_getStoredVolume() term.
+        ctx_.mass_balance.runoff_final_store += lid_.totalStoredVolume();
     }
+
+    // (LID exfiltration / evaporation are folded into the runoff-continuity
+    //  infil / evap terms per-step in accumulateRunoffMassBalance — this
+    //  function is called every routing step, so cumulative terms cannot be
+    //  added here.)
 
     // B8. Compute routing final storage for mass balance
     //     Sum node volumes + link volumes (matching legacy). Nodes use the
@@ -4451,6 +4499,34 @@ void SWMMEngine::initHydraulics() noexcept {
  *          states, and initializes snow, groundwater, and LID solvers.
  */
 void SWMMEngine::initHydrology() noexcept {
+    // 1. Pre-populate each subcatchment's total LID footprint (ft²) BEFORE the
+    //    runoff solver initialises. RunoffSolver::init() sizes the pervious /
+    //    impervious subareas as (full_area − total_lid_area_ft2), but lid_.init()
+    //    (which normally fills total_lid_area_ft2) runs later in the init
+    //    sequence — so without this pre-pass the runoff solver reads zero LID
+    //    area and the LID footprint is never removed from the runoff-producing
+    //    area, making LIDs a near-noop on subcatchment runoff (issue #102 B).
+    //    lid_.init() recomputes the identical sum later; this is idempotent.
+    {
+        int n_sc = ctx_.n_subcatches();
+        if (n_sc > 0) {
+            const double ucfLen2 = ucf::UCF(ucf::LENGTH, ctx_.options)
+                                 * ucf::UCF(ucf::LENGTH, ctx_.options);
+            ctx_.subcatches.total_lid_area_ft2.assign(
+                static_cast<std::size_t>(n_sc), 0.0);
+            const auto& lu = ctx_.lid_usage;
+            for (int j = 0; j < lu.count(); ++j) {
+                auto uj = static_cast<std::size_t>(j);
+                int sc = lu.subcatch_index[uj];
+                if (sc < 0 || sc >= n_sc) continue;
+                int num = (uj < lu.number.size()) ? lu.number[uj] : 1;
+                if (num < 1) num = 1;
+                ctx_.subcatches.total_lid_area_ft2[static_cast<std::size_t>(sc)]
+                    += lu.area[uj] * static_cast<double>(num) / ucfLen2;  // → ft²
+            }
+        }
+    }
+
     // 2. Runoff solver: populate RunoffSoA from subcatchment properties
     runoff_.init(ctx_);
 
@@ -5346,6 +5422,8 @@ double SWMMEngine::reportedNodeVolume(int i, double depth,
 void SWMMEngine::initMassBalance() noexcept {
     // 14. Mass balance: record initial storage (nodes + links, matching legacy)
     ctx_.mass_balance.reset();
+    prev_lid_infil_vol_ = 0.0;  // reset per-step LID infil/evap delta trackers
+    prev_lid_evap_vol_  = 0.0;
     for (int j = 0; j < ctx_.n_nodes(); ++j) {
         // Legacy-convention node volume (junctions => 0) so init storage matches
         // legacy; the internal volume-state is unchanged.
@@ -5363,6 +5441,9 @@ void SWMMEngine::initMassBalance() noexcept {
         ctx_.mass_balance.runoff_init_store +=
             ctx_.subcatches.ponded_depth[uj] * ctx_.subcatches.area[uj];
     }
+    // Initial LID storage (INITSAT-filled soil/storage layers) — symmetric with
+    // the final-storage LID credit so the runoff continuity balances (#102 C).
+    ctx_.mass_balance.runoff_init_store += lid_.totalInitVolume();
 
     // Record initial groundwater storage
     // Legacy: GwaterTotals.initStorage += gwater_getVolume(j) * Subcatch[j].area

--- a/src/engine/core/SWMMEngine.hpp
+++ b/src/engine/core/SWMMEngine.hpp
@@ -409,6 +409,12 @@ private:
     double old_runoff_ms_ = 0.0;    ///< legacy OldRunoffTime (msec)
     double new_runoff_ms_ = 0.0;    ///< legacy NewRunoffTime (msec)
 
+    // Previous cumulative LID exfiltration / evaporation volumes (ft³), so the
+    // per-step delta can be folded into the runoff-continuity infil / evap
+    // outflow terms once per runoff step (issue #102 — legacy VlidInfil/VlidEvap).
+    double prev_lid_infil_vol_ = 0.0;
+    double prev_lid_evap_vol_  = 0.0;
+
     // PARITY: per-subcatchment interpolated wet-weather / GW inflows saved by
     // the Phase-2 interpolation so assembleLateralInflows() can replay
     // legacy's exact per-node accumulation ORDER — routing.c:466-473 adds

--- a/src/engine/hydrology/LID.cpp
+++ b/src/engine/hydrology/LID.cpp
@@ -10,6 +10,7 @@
 
 #include "LID.hpp"
 #include "../core/SimulationContext.hpp"
+#include "../core/UnitConversion.hpp"
 #include <cmath>
 #include <algorithm>
 #include <array>
@@ -25,9 +26,16 @@ namespace lid {
 
 /// Compute drain outflow rate with hysteresis (matching legacy getStorageDrainRate).
 /// Updates drain_open state for next timestep.
+///
+/// coeff/expon are kept in the user's flow-depth units (as the legacy engine
+/// does — they cannot be pre-scaled because the scale depends on `expon`), so
+/// the head is converted ft → user depth, the underdrain equation is evaluated
+/// in user rate units, and the result is converted back to internal ft/sec
+/// (issue #102). ucfRainDepth = UCF(RAINDEPTH), ucfRainfall = UCF(RAINFALL).
 static double getDrainRate(double head, double coeff, double expon,
                            double offset, double hOpen, double hClose,
-                           int& drain_open_state) {
+                           int& drain_open_state,
+                           double ucfRainDepth, double ucfRainfall) {
     double h = head - offset;
     if (h <= 0.0) { drain_open_state = 0; return 0.0; }
 
@@ -42,7 +50,8 @@ static double getDrainRate(double head, double coeff, double expon,
     }
 
     if (coeff <= 0.0) return 0.0;
-    return coeff * std::pow(h, expon);
+    double h_user = h * ucfRainDepth;                        // ft → in|mm
+    return coeff * std::pow(h_user, expon) / ucfRainfall;    // → ft/sec
 }
 
 /// Compute storage exfiltration rate with clogging reduction.
@@ -173,6 +182,17 @@ void LIDSolver::init(SimulationContext& ctx) {
     groups_[6].type = LIDType::VEG_SWALE;
     groups_[7].type = LIDType::ROOF_DISCON;
 
+    // Unit-conversion factors for the model's flow units. LID_CONTROLS /
+    // LID_USAGE parameters arrive in the user's display units (in|mm, in/hr|
+    // mm/hr, ac|ha), but the whole LID solver runs in internal ft / ft-per-sec
+    // / ft². Convert every layer parameter here, mirroring the legacy read*Data
+    // routines in src/legacy/engine/lid.c — without this the underdrain and
+    // conductivity terms are ~10^5-10^6× off (issue #102).
+    const double ucfRainDepth = ucf::UCF(ucf::RAINDEPTH, ctx.options); // ft↔in|mm
+    const double ucfRainfall  = ucf::UCF(ucf::RAINFALL, ctx.options);  // ft/s↔rate
+    const double ucfLength    = ucf::UCF(ucf::LENGTH, ctx.options);    // ft↔ft|m
+    const double ucfLength2   = ucfLength * ucfLength;                 // ft²↔ft²|m²
+
     // If no LID usage data, leave all groups empty
     int n_usage = ctx.lid_usage.count();
     ctx.lid_usage.resize_wb(n_usage);
@@ -210,11 +230,15 @@ void LIDSolver::init(SimulationContext& ctx) {
         int slot = type_cursor[static_cast<size_t>(ti)]++;
         auto us = static_cast<std::size_t>(slot);
 
+        // Underdrain head/rate conversion factors (used by getDrainRate).
+        g.ucf_raindepth = ucfRainDepth;
+        g.ucf_rainfall  = ucfRainfall;
+
         // Usage-level fields
         g.subcatch_idx[us] = ctx.lid_usage.subcatch_index[uj];
         g.control_idx[us]  = li;
-        g.area[us]         = ctx.lid_usage.area[uj];
-        g.full_width[us]   = ctx.lid_usage.width[uj];
+        g.area[us]         = ctx.lid_usage.area[uj] / ucfLength2;  // ft²|m² → ft²
+        g.full_width[us]   = ctx.lid_usage.width[uj] / ucfLength;  // ft|m → ft
         g.from_imperv[us]  = ctx.lid_usage.from_imperv[uj] / 100.0;  // % → fraction
         g.from_perv[us]    = (uj < ctx.lid_usage.from_perv.size())
                              ? ctx.lid_usage.from_perv[uj] / 100.0 : 0.0;
@@ -235,10 +259,10 @@ void LIDSolver::init(SimulationContext& ctx) {
         // SURFACE layer: [0]=StorHt, [1]=VegVolFrac, [2]=Roughness, [3]=SurfSlope, [4]=SideSlope
         if (uli < ctx.lid_controls.surface.size()) {
             const auto& p = ctx.lid_controls.surface[uli];
-            g.surf_store[us]      = p[0];
+            g.surf_store[us]      = p[0] / ucfRainDepth;              // in|mm → ft
             g.surf_void_frac[us]  = (p[1] > 0.0) ? (1.0 - p[1]) : 1.0;
             g.surf_rough[us]      = (p[2] > 0.0) ? p[2] : 0.01;
-            g.surf_slope[us]      = (p[3] > 0.0) ? p[3] : 0.01;
+            g.surf_slope[us]      = (p[3] > 0.0) ? p[3] / 100.0 : 0.01; // % → fraction
             g.surf_side_slope[us] = p[4];  // swale side slope (run/rise)
             g.surf_alpha[us] = 1.49 * std::sqrt(g.surf_slope[us]) / g.surf_rough[us];
         }
@@ -246,42 +270,42 @@ void LIDSolver::init(SimulationContext& ctx) {
         // SOIL layer: [0]=Thick, [1]=Poros, [2]=FC, [3]=WP, [4]=Ksat, [5]=Kslope, [6]=Suction
         if (uli < ctx.lid_controls.soil.size()) {
             const auto& p = ctx.lid_controls.soil[uli];
-            g.soil_thick[us]    = p[0];
+            g.soil_thick[us]    = p[0] / ucfRainDepth;   // in|mm  → ft
             g.soil_poros[us]    = p[1];
             g.soil_fc[us]       = p[2];
             g.soil_wp[us]       = p[3];
-            g.soil_ksat[us]     = p[4];
+            g.soil_ksat[us]     = p[4] / ucfRainfall;    // in/hr|mm/hr → ft/sec
             g.soil_kslope[us]   = p[5];
-            g.soil_suction[us]  = p[6];
+            g.soil_suction[us]  = p[6] / ucfRainDepth;   // in|mm  → ft
         }
 
         // STORAGE layer: [0]=Thick, [1]=VoidRatio, [2]=Ksat, [3]=ClogFactor
         if (uli < ctx.lid_controls.storage.size()) {
             const auto& p = ctx.lid_controls.storage[uli];
-            g.stor_thick[us] = p[0];
-            g.stor_void[us]  = p[1];
-            g.stor_ksat[us]  = p[2];
+            g.stor_thick[us] = p[0] / ucfRainDepth;              // in|mm → ft
+            g.stor_void[us]  = (p[1] > 0.0) ? p[1] / (p[1] + 1.0) : 0.0; // ratio → fraction
+            g.stor_ksat[us]  = p[2] / ucfRainfall;              // in/hr|mm/hr → ft/sec
             g.stor_clog[us]  = p[3];
         }
 
         // DRAIN layer: [0]=Coeff, [1]=Expon, [2]=Offset, [3]=Delay, [4]=hOpen, [5]=hClose
         if (uli < ctx.lid_controls.drain.size()) {
             const auto& p = ctx.lid_controls.drain[uli];
-            g.drain_coeff[us]  = p[0];
-            g.drain_expon[us]  = p[1];
-            g.drain_offset[us] = p[2];
-            g.drain_delay[us]  = p[3];
-            g.drain_hopen[us]  = p[4];
-            g.drain_hclose[us] = p[5];
+            g.drain_coeff[us]  = p[0];                    // user units; see getDrainRate
+            g.drain_expon[us]  = p[1];                    // dimensionless
+            g.drain_offset[us] = p[2] / ucfRainDepth;     // in|mm → ft
+            g.drain_delay[us]  = p[3] * 3600.0;           // hours → seconds
+            g.drain_hopen[us]  = p[4] / ucfRainDepth;     // in|mm → ft
+            g.drain_hclose[us] = p[5] / ucfRainDepth;     // in|mm → ft
         }
 
         // PAVEMENT layer: [0]=Thick, [1]=VoidRatio, [2]=FracImperv, [3]=Ksat, [4]=ClogFactor, [5]=RegenDays
         if (uli < ctx.lid_controls.pavement.size()) {
             const auto& p = ctx.lid_controls.pavement[uli];
-            g.pave_thick[us]       = p[0];
-            g.pave_void[us]        = p[1];
+            g.pave_thick[us]       = p[0] / ucfRainDepth;               // in|mm → ft
+            g.pave_void[us]        = (p[1] > 0.0) ? p[1] / (p[1] + 1.0) : 0.0; // ratio → fraction
             g.pave_imperv_frac[us] = p[2];
-            g.pave_ksat[us]        = p[3];
+            g.pave_ksat[us]        = p[3] / ucfRainfall;               // in/hr|mm/hr → ft/sec
             g.pave_clog_factor[us] = p[4];
             if (p[5] > 0.0) {
                 g.pave_regen_days[us] = p[5];
@@ -294,13 +318,13 @@ void LIDSolver::init(SimulationContext& ctx) {
         // DRAINMAT layer: [0]=Thick, [1]=VoidRatio, [2]=Roughness
         if (uli < ctx.lid_controls.drainmat.size()) {
             const auto& p = ctx.lid_controls.drainmat[uli];
-            g.drainmat_thick[us] = p[0];
+            g.drainmat_thick[us] = p[0] / ucfRainDepth;   // in|mm → ft
             g.drainmat_void[us]  = p[1];
             g.drainmat_rough[us] = p[2];
         }
 
-        // Initial saturation
-        double initSat = ctx.lid_usage.init_sat[uj];
+        // Initial saturation (percent → fraction, legacy x[2]/100)
+        double initSat = ctx.lid_usage.init_sat[uj] / 100.0;
         if (g.soil_thick[us] > 0.0) {
             g.soil_moist[us] = g.soil_wp[us]
                              + initSat * (g.soil_poros[us] - g.soil_wp[us]);
@@ -413,7 +437,8 @@ void LIDSolver::batchBioCellFlux(LIDGroupSoA& g, double rainfall,
         double drain = getDrainRate(g.stor_depth[ui], g.drain_coeff[ui],
                                      g.drain_expon[ui], g.drain_offset[ui],
                                      g.drain_hopen[ui], g.drain_hclose[ui],
-                                     g.drain_open[ui]);
+                                     g.drain_open[ui],
+                                     g.ucf_raindepth, g.ucf_rainfall);
 
         // Surface overflow
         double overflow = 0.0;
@@ -435,9 +460,20 @@ void LIDSolver::batchBioCellFlux(LIDGroupSoA& g, double rainfall,
             g.soil_moist[ui] = std::min(g.soil_moist[ui], g.soil_poros[ui]);
         }
 
-        // Storage depth update
+        // Storage depth update. Bound the storage outflows (exfil + drain) to
+        // the water available this step, else the surplus is clamped out of
+        // storage yet still reported as exfiltration/drain outflow — corrupting
+        // the water balance once those terms are credited to the continuity
+        // (issue #102). Scale both together so their ratio is preserved.
         double stor_void = g.stor_void[ui];
         if (stor_void > 0.0) {
+            double avail = soil_perc + g.stor_depth[ui] * stor_void / dt;  // ft/s
+            double out   = exfil + drain;
+            if (out > avail && out > 0.0) {
+                double scale = std::max(avail, 0.0) / out;
+                exfil *= scale;
+                drain *= scale;
+            }
             g.stor_depth[ui] += (soil_perc - exfil - drain) * dt / stor_void;
             g.stor_depth[ui] = std::max(g.stor_depth[ui], 0.0);
             g.stor_depth[ui] = std::min(g.stor_depth[ui], g.stor_thick[ui]);
@@ -497,7 +533,8 @@ void LIDSolver::batchBarrelFlux(LIDGroupSoA& g, double rainfall, double dt) {
         if (delay_ok) {
             drain = getDrainRate(new_depth, g.drain_coeff[ui], g.drain_expon[ui],
                                  g.drain_offset[ui], g.drain_hopen[ui],
-                                 g.drain_hclose[ui], g.drain_open[ui]);
+                                 g.drain_hclose[ui], g.drain_open[ui],
+                                 g.ucf_raindepth, g.ucf_rainfall);
             drain = std::min(drain, new_depth / dt);
             new_depth -= drain * dt;
         }
@@ -580,7 +617,8 @@ void LIDSolver::batchInfilTrenchFlux(LIDGroupSoA& g, double rainfall,
             storageDrain = getDrainRate(storageDepth, g.drain_coeff[ui],
                                         g.drain_expon[ui], g.drain_offset[ui],
                                         g.drain_hopen[ui], g.drain_hclose[ui],
-                                        g.drain_open[ui]);
+                                        g.drain_open[ui],
+                                        g.ucf_raindepth, g.ucf_rainfall);
 
         // --- Limit exfiltration (can't exceed available inflow + stored volume) ---
         double maxRate = storageInflow - storageEvap
@@ -1080,7 +1118,8 @@ void LIDSolver::batchPavementFlux(LIDGroupSoA& g, double rainfall,
         double storageDrain = getDrainRate(storageDepth, g.drain_coeff[ui],
                                             g.drain_expon[ui], g.drain_offset[ui],
                                             g.drain_hopen[ui], g.drain_hclose[ui],
-                                            g.drain_open[ui]);
+                                            g.drain_open[ui],
+                                            g.ucf_raindepth, g.ucf_rainfall);
 
         // --- adjacency saturation checks (from legacy pavementFluxRates) ---
 
@@ -1289,9 +1328,10 @@ void LIDSolver::batchRoofDisconFlux(LIDGroupSoA& g, double rainfall,
         }
 
         // --- drain (downspout): fraction of surface outflow up to drain_coeff ---
-        // Legacy: StorageDrain = MIN(drain.coeff/UCF(RAINFALL), SurfaceOutflow)
-        // In internal units drain_coeff is already in ft/s
-        double storageDrain = std::min(g.drain_coeff[ui], surfaceOutflow);
+        // Legacy: StorageDrain = MIN(drain.coeff/UCF(RAINFALL), SurfaceOutflow).
+        // drain_coeff is stored in user rate units, so convert to ft/s (#102).
+        double storageDrain = std::min(g.drain_coeff[ui] / g.ucf_rainfall,
+                                       surfaceOutflow);
         surfaceOutflow -= storageDrain;
 
         // --- Euler integration of surface depth ---
@@ -1318,6 +1358,54 @@ void LIDSolver::batchRoofDisconFlux(LIDGroupSoA& g, double rainfall,
         g.wb_final_vol[ui]   = totalVolume;
         g.vol_treated[ui]   += surfaceInflow * dt;
     }
+}
+
+// ============================================================================
+// Stored-volume queries — feed the runoff-continuity storage term (#102 C)
+// ============================================================================
+
+double LIDSolver::totalStoredVolume() const {
+    double vol = 0.0;
+    for (const auto& g : groups_) {
+        for (int i = 0; i < g.count; ++i) {
+            auto ui = static_cast<std::size_t>(i);
+            vol += g.wb_final_vol[ui] * g.area[ui];  // ft depth × ft² = ft³
+        }
+    }
+    return vol;
+}
+
+double LIDSolver::totalInitVolume() const {
+    double vol = 0.0;
+    for (const auto& g : groups_) {
+        for (int i = 0; i < g.count; ++i) {
+            auto ui = static_cast<std::size_t>(i);
+            vol += g.wb_init_vol[ui] * g.area[ui];
+        }
+    }
+    return vol;
+}
+
+double LIDSolver::totalInfilVolume() const {
+    double vol = 0.0;
+    for (const auto& g : groups_) {
+        for (int i = 0; i < g.count; ++i) {
+            auto ui = static_cast<std::size_t>(i);
+            vol += g.wb_infil[ui] * g.area[ui];  // ft depth × ft² = ft³
+        }
+    }
+    return vol;
+}
+
+double LIDSolver::totalEvapVolume() const {
+    double vol = 0.0;
+    for (const auto& g : groups_) {
+        for (int i = 0; i < g.count; ++i) {
+            auto ui = static_cast<std::size_t>(i);
+            vol += g.wb_evap[ui] * g.area[ui];
+        }
+    }
+    return vol;
 }
 
 // ============================================================================

--- a/src/engine/hydrology/LID.cpp
+++ b/src/engine/hydrology/LID.cpp
@@ -234,11 +234,19 @@ void LIDSolver::init(SimulationContext& ctx) {
         g.ucf_raindepth = ucfRainDepth;
         g.ucf_rainfall  = ucfRainfall;
 
-        // Usage-level fields
+        // Usage-level fields. Fold the replicate count (Number) into area and
+        // width — legacy aggregates as lidArea = area × number everywhere
+        // (lid.c:1688 runon divisor, 1168 subcatch total, 1445 stored volume).
+        // Scaling BOTH area and width keeps the Manning width/area ratio, so
+        // the depth-based per-unit dynamics are those of one representative
+        // unit while all flux/volume aggregation covers every replicate.
+        int num = (uj < ctx.lid_usage.number.size()) ? ctx.lid_usage.number[uj] : 1;
+        if (num < 1) num = 1;
+        double n_units = static_cast<double>(num);
         g.subcatch_idx[us] = ctx.lid_usage.subcatch_index[uj];
         g.control_idx[us]  = li;
-        g.area[us]         = ctx.lid_usage.area[uj] / ucfLength2;  // ft²|m² → ft²
-        g.full_width[us]   = ctx.lid_usage.width[uj] / ucfLength;  // ft|m → ft
+        g.area[us]         = ctx.lid_usage.area[uj] * n_units / ucfLength2;  // ft²|m² → ft²
+        g.full_width[us]   = ctx.lid_usage.width[uj] * n_units / ucfLength;  // ft|m → ft
         g.from_imperv[us]  = ctx.lid_usage.from_imperv[uj] / 100.0;  // % → fraction
         g.from_perv[us]    = (uj < ctx.lid_usage.from_perv.size())
                              ? ctx.lid_usage.from_perv[uj] / 100.0 : 0.0;

--- a/src/engine/hydrology/LID.hpp
+++ b/src/engine/hydrology/LID.hpp
@@ -68,6 +68,13 @@ struct LIDGroupSoA {
     LIDType type = LIDType::BIO_CELL;
     int count = 0;
 
+    // Unit-conversion factors for the model's flow units (legacy UCF()).
+    // Layer parameters are converted to internal ft / ft-per-sec at init();
+    // these two factors also drive the underdrain head/rate conversion in
+    // getDrainRate(). Defaults are the US-customary values (issue #102).
+    double ucf_raindepth = 12.0;    ///< ft → in|mm  (RAINDEPTH)
+    double ucf_rainfall  = 43200.0; ///< ft/sec → in/hr|mm/hr  (RAINFALL)
+
     std::vector<int> subcatch_idx;     ///< Which subcatchment this unit belongs to
     std::vector<int> control_idx;      ///< LID control index (into ctx.lid_controls)
     std::vector<double> area;          ///< Unit area (ft2)
@@ -178,6 +185,18 @@ public:
     LIDGroupSoA& group(int type_index) { return groups_[static_cast<size_t>(type_index)]; }
     const LIDGroupSoA& group(int type_index) const { return groups_[static_cast<size_t>(type_index)]; }
     int numGroups() const { return static_cast<int>(groups_.size()); }
+
+    /// Total water currently stored across all LID units (ft³): per-unit
+    /// stored depth (wb_final_vol, ft) × unit area (ft²). Feeds the
+    /// subcatchment runoff-continuity storage term (issue #102 C).
+    double totalStoredVolume() const;
+    /// Total initial LID storage (ft³): wb_init_vol (ft) × area (ft²).
+    double totalInitVolume() const;
+    /// Cumulative LID exfiltration to native soil (ft³): wb_infil × area.
+    /// Added to the runoff-continuity infiltration term (legacy VlidInfil).
+    double totalInfilVolume() const;
+    /// Cumulative LID evaporation (ft³): wb_evap × area (legacy VlidEvap).
+    double totalEvapVolume() const;
 
     /**
      * @brief Compute LID performance for all units (batch by type).

--- a/tests/unit/engine/test_lid.cpp
+++ b/tests/unit/engine/test_lid.cpp
@@ -142,12 +142,15 @@ TEST(LIDModelBuilder, SingleBioCellPopulated) {
 
     const auto& g = solver.group(0); // BIO_CELL
     EXPECT_EQ(g.count, 1);
-    EXPECT_NEAR(g.surf_store[0], 0.5, 1e-10);
-    EXPECT_NEAR(g.soil_thick[0], 1.5, 1e-10);
+    // Layer depths arrive in user units (inches, US) and are converted to
+    // internal ft at init (÷ UCF(RAINDEPTH) = 12); porosity is dimensionless
+    // and the drain coeff stays in user units (issue #102).
+    EXPECT_NEAR(g.surf_store[0], 0.5 / 12.0, 1e-10);
+    EXPECT_NEAR(g.soil_thick[0], 1.5 / 12.0, 1e-10);
     EXPECT_NEAR(g.soil_poros[0], 0.45, 1e-10);
-    EXPECT_NEAR(g.stor_thick[0], 1.0, 1e-10);
+    EXPECT_NEAR(g.stor_thick[0], 1.0 / 12.0, 1e-10);
     EXPECT_NEAR(g.drain_coeff[0], 0.5, 1e-10);
-    EXPECT_NEAR(g.area[0], 1000.0, 1e-10);
+    EXPECT_NEAR(g.area[0], 1000.0, 1e-10);  // ft² (US: UCF(LENGTH)=1)
 }
 
 TEST(LIDModelBuilder, InitialSaturationSetsState) {
@@ -156,7 +159,7 @@ TEST(LIDModelBuilder, InitialSaturationSetsState) {
         {1.5, 0.45, 0.20, 0.10, 1e-5, 30.0, 6.0},
         {1.0, 0.5, 0.0, 0.0},
         {0.0, 0.5, 0.0, 0.0, 0.0, 0.0},
-        1000.0, 50.0, 0.5  // 50% initial saturation
+        1000.0, 50.0, 50.0  // init_sat is a PERCENT (0-100): 50 → 0.5 fraction
     );
 
     LIDSolver solver;
@@ -165,8 +168,8 @@ TEST(LIDModelBuilder, InitialSaturationSetsState) {
     const auto& g = solver.group(0);
     // Soil: wp + initSat * (poros - wp) = 0.10 + 0.5*(0.45 - 0.10) = 0.275
     EXPECT_NEAR(g.soil_moist[0], 0.275, 1e-10);
-    // Storage: initSat * thickness = 0.5 * 1.0 = 0.5
-    EXPECT_NEAR(g.stor_depth[0], 0.5, 1e-10);
+    // Storage: initSat * thickness (thickness converted in → ft: 1.0/12).
+    EXPECT_NEAR(g.stor_depth[0], 0.5 * (1.0 / 12.0), 1e-10);
 }
 
 TEST(LIDModelBuilder, MultipleTypesDistributed) {
@@ -218,12 +221,13 @@ TEST(LIDModelBuilder, MultipleTypesDistributed) {
 
 TEST(LIDModelBuilder, ManningAlphaComputed) {
     auto ctx = makeLidContext("BC",
-        {0.5, 0.0, 0.05, 0.02, 0.0},  // roughness=0.05, slope=2%
+        {0.5, 0.0, 0.05, 2.0, 0.0},  // roughness=0.05, slope entered as % (2 → 0.02)
         {0,0,0,0,0,0,0}, {0,0,0,0}, {0,0,0,0,0,0});
 
     LIDSolver solver;
     solver.init(ctx);
     const auto& g = solver.group(0);
+    // surf_slope is converted %→fraction (2.0/100 = 0.02); alpha = 1.49·√s/n.
     double expected_alpha = 1.49 * std::sqrt(0.02) / 0.05;
     EXPECT_NEAR(g.surf_alpha[0], expected_alpha, 1e-6);
 }

--- a/tests/unit/engine/test_lid.cpp
+++ b/tests/unit/engine/test_lid.cpp
@@ -219,6 +219,27 @@ TEST(LIDModelBuilder, MultipleTypesDistributed) {
     EXPECT_EQ(solver.group(2).count, 0); // GR
 }
 
+TEST(LIDModelBuilder, ReplicateNumberScalesAreaAndWidth) {
+    auto ctx = makeLidContext("BC",
+        {0.5, 0.0, 0.1, 1.0, 0.0},
+        {1.5, 0.45, 0.20, 0.10, 1e-5, 30.0, 6.0},
+        {1.0, 0.5, 0.0, 0.0},
+        {0.0, 0.5, 0.0, 0.0, 0.0, 0.0});
+    ctx.lid_usage.number[0] = 3;  // three replicate units
+
+    LIDSolver solver;
+    solver.init(ctx);
+
+    const auto& g = solver.group(0);
+    // Legacy aggregates lidArea = area × number (lid.c:1688) and scales width
+    // with it so the Manning width/area ratio — and thus the per-unit depth
+    // dynamics — are unchanged while flux/volume totals cover every replicate.
+    EXPECT_NEAR(g.area[0], 3.0 * 1000.0, 1e-10);
+    EXPECT_NEAR(g.full_width[0], 3.0 * 50.0, 1e-10);
+    // Subcatchment LID footprint must also carry the replicate count.
+    EXPECT_NEAR(ctx.subcatches.total_lid_area_ft2[0], 3.0 * 1000.0, 1e-10);
+}
+
 TEST(LIDModelBuilder, ManningAlphaComputed) {
     auto ctx = makeLidContext("BC",
         {0.5, 0.0, 0.05, 2.0, 0.0},  // roughness=0.05, slope entered as % (2 → 0.02)


### PR DESCRIPTION
…ng (#102)
## Summary
The v6 LID module (src/engine/hydrology/LID.cpp) is a data-oriented rewrite of the legacy lid.c/lidproc.c. Two families of behaviour that legacy implements in read*Data (lid.c) and subcatch_getRunoff / subcatch_getStorage / massbal_getRunoffError (subcatch.c, massbal.c) were not carried over, so a model with an active underdrain reported a runoff continuity error of 10^5-10^6 % and LID Total Inflow of ~10^8 mm.

## Root cause and fix:

1. Unit conversions (the headline bug). LID_CONTROLS / LID_USAGE parameters arrive in the user's display units (in|mm, in/hr|mm/hr, ac|ha, %), but the LID solver runs in internal ft / ft-per-sec / ft². The rewrite copied them through raw. Restored the legacy conversion catalogue at LIDSolver::init() (thickness/suction/offset/heads /UCF(RAINDEPTH); conductivities /UCF(RAINFALL); storage & pavement void-ratio->fraction; surface slope /100; usage area /SQR(UCF(LENGTH)); width /UCF(LENGTH); drain delay *3600; init-sat /100). Drain coeff/expon stay in user units and are converted inside getDrainRate() exactly as legacy getStorageDrainRate (head ft->user, evaluate, /UCF(RAINFALL)). Gage rainfall (stored in in/hr per Gage.cpp) is converted to ft/s where it feeds the LID inflow. refreshLIDDrainParams mirrors the conversions.

2. Subcatchment / mass-balance coupling. Once the LID actually functions, several legacy couplings were still missing:
   - total_lid_area_ft2 is now populated before RunoffSolver::init so the LID footprint is removed from the runoff-producing subarea (was read as zero -> LID a noop on runoff).
   - LID stored volume (lid_getStoredVolume) credited to runoff final/init storage; LID exfiltration & evaporation (VlidInfil/VlidEvap) folded into the runoff-continuity infil/evap terms as a per-step delta.
   - Captured fromImperv/fromPerv runon removed from the subcatch outlet (legacy -VlidIn); the runoff mass-balance accumulation moved after the LID routing so those adjustments are counted.
   - No-target underdrain discharges to the subcatchment outlet instead of recirculating as runon-to-self.
   - Bio-cell storage outflows (exfil+drain) bounded to available water so the reported fluxes are physical (other LID types already clamp).
   - Fixed a 2x infiltration double-count exposed by the area fix (non-LID -area-averaged rates were multiplied by the full subcatchment area).

## Verification 
(built from the v6.0.0-alpha.2 tag, compared to EPA SWMM5 5.2 via pyswmm 2.1.0): the minimal underdrain reproducer's continuity goes from -652,313 % to -0.027 % (SI and US), matching EPA; surface runoff, LID inflow and final storage match EPA to reported precision. Across six diverse real LID models (lid_placement A-D, Aarhus with/without underdrain) continuity is now < 0.03 % (catastrophic ones from 10^5-10^6 %). A differential vs a clean unpatched build over 29 non-LID engine models shows zero continuity change. The engine's own ctest suite passes 76/77 (the one failure, test_engine_xsect_parity, fails identically on the clean tree — pre-existing fast-kernel non-bit-exactness, unrelated to this change). Three LIDModelBuilder unit tests that had encoded the pre-fix un-converted values are updated to feed INP user units and assert the converted internal values.

## Minimal reproducer

```
[TITLE]
Minimal LID-underdrain continuity reproducer (1 subcatchment)
[OPTIONS]
FLOW_UNITS LPS
INFILTRATION HORTON
FLOW_ROUTING DYNWAVE
START_DATE 01/01/2024
START_TIME 00:00:00
END_DATE 01/01/2024
END_TIME 03:30:00
REPORT_STEP 00:01:00
WET_STEP 00:01:00
ROUTING_STEP 00:00:10
[RAINGAGES]
RG1 VOLUME 0:30 1 TIMESERIES TS_RAIN
[SUBCATCHMENTS]
S1 RG1 J1 0.4 85 80 1 0
[SUBAREAS]
S1 0.015 0.13 2 5 25 OUTLET 100
[INFILTRATION]
S1 75 3 4 7 0
[LID_CONTROLS]
BIO1 BC
BIO1 SURFACE 300 0.2 0.1 1 0
BIO1 SOIL 600 0.35 0.2 0.1 150 10 50
BIO1 STORAGE 300 0.95 0 0 YES
BIO1 DRAIN 0.5 0.5 0 0
[LID_USAGE]
S1 BIO1 1 2000 0 0 100 0
[JUNCTIONS]
J1 1 3 0 0 0
[OUTFALLS]
OUT1 0 FREE NO
[CONDUITS]
C1 J1 OUT1 120 0.013 0 0 0
[XSECTIONS]
C1 CIRCULAR 1 0 0 0 1
[TIMESERIES]
TS_RAIN 00:00 0.0
TS_RAIN 00:30 5.0
TS_RAIN 01:00 60.0
TS_RAIN 01:30 20.0
TS_RAIN 02:00 5.0
TS_RAIN 02:30 0.0
TS_RAIN 03:00 0.0
```