### PR TITLE
feat(uncertainty): PR 12a — 2D ROM uncertainty quantiles in HDF5 output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ retroactive.
 
 ### Added
 
+- **Per-cell 2D uncertainty quantiles in the HDF5 output.** When a 2D uncertainty ROM is active
+  (`[2D_ROM]`/`[UNCERTAINTY]`), `Default2DOutputPlugin` now writes three per-face datasets
+  `Mesh2_face_rom_q05`, `Mesh2_face_rom_q50`, `Mesh2_face_rom_q95` (overland depth, m) alongside the
+  deterministic fields, sourced from `SpectralROM::computeQuantiles()` via new
+  `SimulationSnapshot::surface_rom_q05/q50/q95` fields filled in `fillSurfaceSnapshot()`. The
+  datasets are created lazily on the first snapshot that carries them, so runs without a 2D ROM
+  produce a byte-identical file. `q50` tracks the deterministic depth by construction, so no
+  deterministic output field or mass balance is affected.
 - **Decoupled 1D/2D timesteps with conservative per-step exchange booking.** `COUPLING_INTERVAL` is
   mapped to a physical time window and the old step-count gating is retired, so the 2D advance
   cadence no longer follows 1D variable-step shrinkage. Junction exchange is accumulated per 1D step

--- a/include/openswmm/plugin_sdk/SimulationSnapshot.hpp
+++ b/include/openswmm/plugin_sdk/SimulationSnapshot.hpp
@@ -247,6 +247,15 @@ struct SimulationSnapshot {
     std::vector<double> surface_stat_max_depth;    ///< Max overland depth ψ_o (m), per face
     std::vector<double> surface_stat_max_velocity; ///< Max cell speed |v| (m/s), per face
     std::vector<double> surface_stat_max_cont_err; ///< Max |continuity residual| (m³/s), per face
+
+    // Optional per-face uncertainty quantiles from the 2D spectral ROM
+    // ([2D_ROM]/[UNCERTAINTY]). Empty when no 2D ROM is active; otherwise sized
+    // `surface_tri_count` and refreshed at report cadence. q50 tracks the
+    // deterministic depth by construction (nominal member is zero-deviation),
+    // so these are purely additive and change no deterministic output field.
+    std::vector<double> surface_rom_q05; ///< 5th-percentile overland depth (m), per face
+    std::vector<double> surface_rom_q50; ///< Median overland depth (m), per face
+    std::vector<double> surface_rom_q95; ///< 95th-percentile overland depth (m), per face
 };
 
 } /* namespace openswmm */

--- a/src/engine/2d/output/Default2DOutputPlugin.cpp
+++ b/src/engine/2d/output/Default2DOutputPlugin.cpp
@@ -122,6 +122,23 @@ void Default2DOutputPlugin::writeFaceEnvelope(hid_t ds, const double* data) {
     H5Dwrite(ds, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, data);
 }
 
+void Default2DOutputPlugin::ensureRomQuantileDatasets() {
+    if (ds_face_rom_q50_ != H5I_INVALID_HID) return;  // created once, on first use
+    hsize_t zero2[2]      = { 0, n_faces_ };
+    hsize_t face_chunk[2] = { 1, n_faces_ };
+    auto make = [&](const char* name, const char* long_name) -> hid_t {
+        hid_t ds = createUnlimitedDataset(name, 2, zero2, face_chunk);
+        writeStringAttr(ds, "long_name", long_name);
+        writeStringAttr(ds, "units", "m");
+        writeStringAttr(ds, "mesh", "Mesh2");
+        writeStringAttr(ds, "location", "face");
+        return ds;
+    };
+    ds_face_rom_q05_ = make("Mesh2_face_rom_q05", "5th-percentile overland depth (2D uncertainty ROM)");
+    ds_face_rom_q50_ = make("Mesh2_face_rom_q50", "median overland depth (2D uncertainty ROM)");
+    ds_face_rom_q95_ = make("Mesh2_face_rom_q95", "95th-percentile overland depth (2D uncertainty ROM)");
+}
+
 // ============================================================================
 // Lifecycle
 // ============================================================================
@@ -518,6 +535,18 @@ int Default2DOutputPlugin::update(const SimulationSnapshot& snap) {
         writeFaceEnvelope(ds_face_max_continuity_err_,
                           snap.surface_stat_max_cont_err.data());
 
+    // Optional per-face 2D ROM uncertainty quantiles (present only when a 2D
+    // ROM ran). Lazily create the datasets the first time they appear so a
+    // run without a ROM writes a byte-identical file.
+    if (snap.surface_rom_q50.size() == n_faces_ &&
+        snap.surface_rom_q05.size() == n_faces_ &&
+        snap.surface_rom_q95.size() == n_faces_) {
+        ensureRomQuantileDatasets();
+        extendAndWrite2D(ds_face_rom_q05_, snap.surface_rom_q05.data(), n_faces_);
+        extendAndWrite2D(ds_face_rom_q50_, snap.surface_rom_q50.data(), n_faces_);
+        extendAndWrite2D(ds_face_rom_q95_, snap.surface_rom_q95.data(), n_faces_);
+    }
+
     ++n_steps_;
     return 0;
 }
@@ -576,6 +605,9 @@ int Default2DOutputPlugin::finalize(const SimulationContext& ctx) {
     closeDS(ds_edge_flux_);
     closeDS(ds_node_head_);
     closeDS(ds_node_depth_);
+    closeDS(ds_face_rom_q05_);
+    closeDS(ds_face_rom_q50_);
+    closeDS(ds_face_rom_q95_);
     closeDS(ds_face_max_depth_);
     closeDS(ds_face_max_velocity_);
     closeDS(ds_face_max_continuity_err_);

--- a/src/engine/2d/output/Default2DOutputPlugin.hpp
+++ b/src/engine/2d/output/Default2DOutputPlugin.hpp
@@ -147,6 +147,13 @@ private:
     hid_t ds_node_head_            = H5I_INVALID_HID;
     hid_t ds_node_depth_           = H5I_INVALID_HID;
 
+    // Optional per-face 2D ROM uncertainty quantiles. Created lazily on the
+    // first update() that carries them, so a run without a 2D ROM produces a
+    // byte-identical file (these three datasets simply do not appear).
+    hid_t ds_face_rom_q05_         = H5I_INVALID_HID;
+    hid_t ds_face_rom_q50_         = H5I_INVALID_HID;
+    hid_t ds_face_rom_q95_         = H5I_INVALID_HID;
+
     // Cumulative envelopes — fixed [nFace], overwritten in place each update()
     hid_t ds_face_max_depth_          = H5I_INVALID_HID;
     hid_t ds_face_max_velocity_       = H5I_INVALID_HID;
@@ -170,6 +177,8 @@ private:
                                     const char* units);
     /// Overwrite a fixed [nFace] dataset in place with the latest envelope.
     void writeFaceEnvelope(hid_t ds, const double* data);
+    /// Create the three optional per-face 2D ROM quantile datasets on demand.
+    void ensureRomQuantileDatasets();
 };
 
 } // namespace openswmm::twoD

--- a/src/engine/core/SWMMEngine.cpp
+++ b/src/engine/core/SWMMEngine.cpp
@@ -3987,6 +3987,16 @@ void SWMMEngine::fillSurfaceSnapshot(SimulationSnapshot& snap) const noexcept {
     snap.surface_stat_max_depth    = st.stat_max_depth;
     snap.surface_stat_max_velocity = st.stat_max_velocity;
     snap.surface_stat_max_cont_err = st.stat_max_cont_err;
+    // Optional 2D ROM uncertainty quantiles — copied only when a 2D ROM is
+    // active and has produced per-face quantiles (refreshed at report cadence).
+    // Additive: q50 tracks the deterministic depth by construction, so this
+    // leaves every deterministic output field and the mass balance untouched.
+    if (const auto* rom = surface_router_.rom();
+        rom && rom->q05.size() == static_cast<std::size_t>(snap.surface_tri_count)) {
+        snap.surface_rom_q05 = rom->q05;
+        snap.surface_rom_q50 = rom->q50;
+        snap.surface_rom_q95 = rom->q95;
+    }
 #else
     (void)snap;
 #endif

--- a/tests/unit/engine/test_2d_surface_routing.cpp
+++ b/tests/unit/engine/test_2d_surface_routing.cpp
@@ -1438,6 +1438,79 @@ TEST(EdgeConveyance, ParserSkipsEmptyTokenList) {
 
 #ifdef OPENSWMM_HAS_2D
 
+TEST(Default2DOutputPlugin, WritesRomQuantileFacesWhenPresent) {
+    namespace fs = std::filesystem;
+
+    MeshData mesh = makeUnitSquareMesh();
+    const int n_tri = mesh.n_triangles();
+    ASSERT_EQ(n_tri, 2);
+
+    openswmm::SimulationSnapshot snap;
+    snap.sim_time            = 0.0;
+    snap.surface_tri_count   = n_tri;
+    snap.surface_vert_count  = mesh.n_vertices();
+    snap.surface_depth         = {0.05, 0.10};
+    snap.surface_head          = {0.05, 0.10};
+    snap.surface_grad_hx       = {0.0,  0.0};
+    snap.surface_grad_hy       = {0.0,  0.0};
+    snap.surface_grad_hx_lim   = {0.0,  0.0};
+    snap.surface_grad_hy_lim   = {0.0,  0.0};
+    snap.surface_rainfall      = {0.0,  0.0};
+    snap.surface_coupling_flux = {0.0,  0.0};
+    snap.surface_net_source    = {0.0,  0.0};
+    snap.surface_face_vx       = {0.0,  0.0};
+    snap.surface_face_vy       = {0.0,  0.0};
+    snap.surface_continuity_err = {0.0,  0.0};
+    snap.surface_edge_flux     = {0.0, 0.0, 0.0,  0.0, 0.0, 0.0};
+    snap.surface_vert_head     = {0.0, 0.0, 0.0,  0.0};
+    // The three optional 2D ROM quantile faces (monotone q05 <= q50 <= q95).
+    snap.surface_rom_q05 = {0.02, 0.06};
+    snap.surface_rom_q50 = {0.05, 0.10};
+    snap.surface_rom_q95 = {0.09, 0.15};
+
+    const fs::path h5_path = fs::temp_directory_path() /
+                              "openswmm_test_2d_rom_output.h5";
+    fs::remove(h5_path);
+
+    Default2DOutputPlugin plugin(h5_path.string());
+    ASSERT_EQ(plugin.initialize({}, nullptr), 0);
+    openswmm::SimulationContext ctx{};
+    ASSERT_EQ(plugin.validate(ctx), 0);
+    ASSERT_EQ(plugin.prepare(ctx),  0);
+    plugin.prepareMeshAndDatasets(mesh);
+    ASSERT_EQ(plugin.update(snap), 0);
+    ASSERT_EQ(plugin.finalize(ctx), 0);
+
+    ASSERT_TRUE(fs::exists(h5_path));
+    hid_t file_id = H5Fopen(h5_path.string().c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
+    ASSERT_GE(file_id, 0);
+    auto exists = [file_id](const char* name) {
+        return H5Lexists(file_id, name, H5P_DEFAULT) > 0;
+    };
+    EXPECT_TRUE(exists("Mesh2_face_rom_q05"));
+    EXPECT_TRUE(exists("Mesh2_face_rom_q50"));
+    EXPECT_TRUE(exists("Mesh2_face_rom_q95"));
+
+    // q95 face is [1, n_tri] and carries exactly the values we supplied.
+    {
+        hid_t ds = H5Dopen2(file_id, "Mesh2_face_rom_q95", H5P_DEFAULT);
+        ASSERT_GE(ds, 0);
+        hid_t space = H5Dget_space(ds);
+        hsize_t dims[2] = {0, 0};
+        H5Sget_simple_extent_dims(space, dims, nullptr);
+        EXPECT_EQ(dims[0], 1u);
+        EXPECT_EQ(dims[1], static_cast<hsize_t>(n_tri));
+        std::vector<double> vals(n_tri, 0.0);
+        H5Dread(ds, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, vals.data());
+        EXPECT_NEAR(vals[0], 0.09, 1e-12);
+        EXPECT_NEAR(vals[1], 0.15, 1e-12);
+        H5Sclose(space);
+        H5Dclose(ds);
+    }
+    H5Fclose(file_id);
+    fs::remove(h5_path);
+}
+
 TEST(Default2DOutputPlugin, WritesUgridHdf5WithExpectedDatasets) {
     namespace fs = std::filesystem;
 
@@ -1526,6 +1599,11 @@ TEST(Default2DOutputPlugin, WritesUgridHdf5WithExpectedDatasets) {
     EXPECT_TRUE(exists("Mesh2_face_max_depth"));
     EXPECT_TRUE(exists("Mesh2_face_max_velocity"));
     EXPECT_TRUE(exists("Mesh2_face_max_continuity_err"));
+    // No 2D ROM ran in this case, so the optional quantile faces are absent
+    // (the additive datasets must not perturb a plain 2D output file).
+    EXPECT_FALSE(exists("Mesh2_face_rom_q05"));
+    EXPECT_FALSE(exists("Mesh2_face_rom_q50"));
+    EXPECT_FALSE(exists("Mesh2_face_rom_q95"));
     EXPECT_TRUE(exists("mass_balance_2d"));
     EXPECT_TRUE(exists("time"));
 


### PR DESCRIPTION
Wires the 2D spectral ROM's per-face quantiles into Default2DOutputPlugin, completing the POST_REFORM_PR_CHECKLIST.md PR 12 "12a" item on the marcher-port base (the 1D-side .uncertainty.csv path already exists; 1D's own /rom1d HDF5 group, "12b", is not part of this commit).

- SimulationSnapshot gains surface_rom_q05/q50/q95 (per-face, empty when no 2D ROM is active), populated in SWMMEngine::fillSurfaceSnapshot() from SurfaceRouter2D::rom() when sizes match.
- Default2DOutputPlugin writes three new per-face HDF5 datasets (Mesh2_face_rom_q05/q50/q95, overland depth in m), created lazily on the first update() that carries them so a run without a 2D ROM produces a byte-identical file to before this change.
- q50 tracks the deterministic depth by construction (nominal ROM member is zero-deviation), so no deterministic output field or mass balance is touched.

New test: Default2DOutputPlugin.WritesRomQuantileFacesWhenPresent, plus an absence assertion added to the existing plain-2D-output test. Full ctest gate unaffected (122/123 — only the pre-existing, already- documented regression_rom_coverage red).