### PR TITLE
Hsym2/prh4 quantile gemm

### DIFF
--- a/docs/uncertainty/USER_GUIDE.md
+++ b/docs/uncertainty/USER_GUIDE.md
@@ -1525,7 +1525,7 @@ For a pure 1D sewer network with N=10,000 active nodes, M=50 members, k=20 modes
 |---|---|---|
 | Lanczos eigensolver (one-time at `initialize()`) | ~15 ms | O(N·k) sparse mat-vec; paid once regardless of simulation length |
 | ROM `advance()` per routing step | < 1 μs | M×k = 1,000 scalar exponentials |
-| `computeQuantiles()` per routing step | **~0.45 ms measured** (was ~4.7 ms before PR H4) | M×N reconstruction now one `cblas_dgemm` call (or a portable fallback) instead of a hand-rolled triple loop — measured on Bellinge (real 1020-node network), N=1,011/M=50/k=20, **10.3–10.6× faster**; see below |
+| `computeQuantiles()` per routing step | **~4.4 ms** (was ~46 ms before PR H4) — scaled to N=10,000 | M×N reconstruction now one `cblas_dgemm` call (or a portable fallback) instead of a hand-rolled triple loop. Reconstruction is O(N·M·k), so this row is the *measured* Bellinge result (N=1,011/M=50/k=20: 4.7 ms → 0.45 ms, **10.3–10.6× faster**) scaled linearly by N to match this table's N=10,000; see below for the real measurement |
 | Per-step overhead vs deterministic DYNWAVE | < 1% | DYNWAVE Newton solve dominates at ≫ 1 ms/step |
 
 For a 6-hour storm at 30-second routing intervals (720 steps):
@@ -1540,12 +1540,15 @@ For a 6-hour storm at 30-second routing intervals (720 steps):
 — Apple's Accelerate framework, zero new dependency, with a portable fallback elsewhere) and
 switched the 2D ROM's quantile *selection* from a full sort to three `std::nth_element` calls
 (1D kept the full sort — PR H10's threshold/modality diagnostics need the whole per-node row in
-sorted order, not just the three quantile points). Measured, not estimated (see
-`docs/uncertainty/VALIDATION.md`, "Quantile-reconstruction GEMM (PR H4)"): **10.3–10.6× faster**
-on Bellinge (1D, a real 1020-node network — N=1,011 active nodes/M=50/k=20, 4.7 ms → 0.45 ms per
-call) and **7.0–7.1× faster** at 9,800 triangles/M=50/k=20 (2D, 111 ms → 15.6 ms per call). To
-reduce the remaining cost further: lower M, increase the routing interval, or compute quantiles
-only on output steps rather than every step.
+sorted order, not just the three quantile points). The speedup itself is measured, not estimated
+(see `docs/uncertainty/VALIDATION.md`, "Quantile-reconstruction GEMM (PR H4)," for the full
+numbers) — directly, at the N each benchmark actually ran at, not at the N=10,000 this section
+assumes: **10.3–10.6× faster** on Bellinge (1D, a real network — N=1,011 active nodes/M=50/k=20,
+4.7 ms → 0.45 ms per call) and **7.0–7.1× faster** at 9,800 triangles/M=50/k=20 (2D, 111 ms →
+15.6 ms per call). The table row above scales the Bellinge result linearly by N (reconstruction
+is O(N·M·k)) to match this section's stated N=10,000 — the *ratio* is measured, the *N=10,000
+absolute number* is not. To reduce the remaining cost further: lower M, increase the routing
+interval, or compute quantiles only on output steps rather than every step.
 
 **Lanczos build** requires n_active ≥ 4 conduit-endpoint nodes (outfalls excluded). Build time
 scales as O(N·k·iters) where iters ≈ 3k for typical Lanczos convergence. At N=10,000 and k=20

--- a/docs/uncertainty/USER_GUIDE.md
+++ b/docs/uncertainty/USER_GUIDE.md
@@ -1525,7 +1525,7 @@ For a pure 1D sewer network with N=10,000 active nodes, M=50 members, k=20 modes
 |---|---|---|
 | Lanczos eigensolver (one-time at `initialize()`) | ~15 ms | O(N·k) sparse mat-vec; paid once regardless of simulation length |
 | ROM `advance()` per routing step | < 1 μs | M×k = 1,000 scalar exponentials |
-| `computeQuantiles()` per routing step | ~2 ms | M×N = 500,000 reconstructions + per-node sort |
+| `computeQuantiles()` per routing step | **~4.3 ms measured** (was ~54 ms before PR H4) | M×N reconstruction now one `cblas_dgemm` call (or a portable fallback) instead of a hand-rolled triple loop — measured at N=8,000/M=50/k=30, **12.5× faster**; see below |
 | Per-step overhead vs deterministic DYNWAVE | < 1% | DYNWAVE Newton solve dominates at ≫ 1 ms/step |
 
 For a 6-hour storm at 30-second routing intervals (720 steps):
@@ -1535,10 +1535,16 @@ For a 6-hour storm at 30-second routing intervals (720 steps):
 | Total overhead | ~50× baseline runtime | ~0.5% of baseline |
 | Typical wall time | hours | seconds |
 
-**Quantile reconstruction** (M×N per step) is the dominant 1D ROM cost for large networks.
-For N=10,000 and M=50, each step reconstructs 500,000 head values. At 30 s routing intervals
-this amounts to roughly 700 ms of quantile work per simulated hour. To reduce it: lower M,
-increase the routing interval, or compute quantiles only on output steps rather than every step.
+**Quantile reconstruction** (M×N per step) was the dominant 1D ROM cost for large networks;
+**PR H4** replaced the hand-rolled reconstruction loop with a GEMM call (`RomQuantileGemm.hpp`
+— Apple's Accelerate framework, zero new dependency, with a portable fallback elsewhere) and
+switched the 2D ROM's quantile *selection* from a full sort to three `std::nth_element` calls
+(1D kept the full sort — PR H10's threshold/modality diagnostics need the whole per-node row in
+sorted order, not just the three quantile points). Measured, not estimated (see
+`docs/uncertainty/VALIDATION.md`, "Quantile-reconstruction GEMM (PR H4)"): **12.5× faster** at
+N=8,000/M=50/k=30 (1D, 54.2 ms → 4.3 ms per call) and **7.1× faster** at 9,800 triangles/M=50/k=20
+(2D, 111 ms → 15.6 ms per call). To reduce the remaining cost further: lower M, increase the
+routing interval, or compute quantiles only on output steps rather than every step.
 
 **Lanczos build** requires n_active ≥ 4 conduit-endpoint nodes (outfalls excluded). Build time
 scales as O(N·k·iters) where iters ≈ 3k for typical Lanczos convergence. At N=10,000 and k=20

--- a/docs/uncertainty/USER_GUIDE.md
+++ b/docs/uncertainty/USER_GUIDE.md
@@ -1525,7 +1525,7 @@ For a pure 1D sewer network with N=10,000 active nodes, M=50 members, k=20 modes
 |---|---|---|
 | Lanczos eigensolver (one-time at `initialize()`) | ~15 ms | O(N·k) sparse mat-vec; paid once regardless of simulation length |
 | ROM `advance()` per routing step | < 1 μs | M×k = 1,000 scalar exponentials |
-| `computeQuantiles()` per routing step | **~4.3 ms measured** (was ~54 ms before PR H4) | M×N reconstruction now one `cblas_dgemm` call (or a portable fallback) instead of a hand-rolled triple loop — measured at N=8,000/M=50/k=30, **12.5× faster**; see below |
+| `computeQuantiles()` per routing step | **~0.45 ms measured** (was ~4.7 ms before PR H4) | M×N reconstruction now one `cblas_dgemm` call (or a portable fallback) instead of a hand-rolled triple loop — measured on Bellinge (real 1020-node network), N=1,011/M=50/k=20, **10.3–10.6× faster**; see below |
 | Per-step overhead vs deterministic DYNWAVE | < 1% | DYNWAVE Newton solve dominates at ≫ 1 ms/step |
 
 For a 6-hour storm at 30-second routing intervals (720 steps):
@@ -1541,10 +1541,11 @@ For a 6-hour storm at 30-second routing intervals (720 steps):
 switched the 2D ROM's quantile *selection* from a full sort to three `std::nth_element` calls
 (1D kept the full sort — PR H10's threshold/modality diagnostics need the whole per-node row in
 sorted order, not just the three quantile points). Measured, not estimated (see
-`docs/uncertainty/VALIDATION.md`, "Quantile-reconstruction GEMM (PR H4)"): **12.5× faster** at
-N=8,000/M=50/k=30 (1D, 54.2 ms → 4.3 ms per call) and **7.1× faster** at 9,800 triangles/M=50/k=20
-(2D, 111 ms → 15.6 ms per call). To reduce the remaining cost further: lower M, increase the
-routing interval, or compute quantiles only on output steps rather than every step.
+`docs/uncertainty/VALIDATION.md`, "Quantile-reconstruction GEMM (PR H4)"): **10.3–10.6× faster**
+on Bellinge (1D, a real 1020-node network — N=1,011 active nodes/M=50/k=20, 4.7 ms → 0.45 ms per
+call) and **7.0–7.1× faster** at 9,800 triangles/M=50/k=20 (2D, 111 ms → 15.6 ms per call). To
+reduce the remaining cost further: lower M, increase the routing interval, or compute quantiles
+only on output steps rather than every step.
 
 **Lanczos build** requires n_active ≥ 4 conduit-endpoint nodes (outfalls excluded). Build time
 scales as O(N·k·iters) where iters ≈ 3k for typical Lanczos convergence. At N=10,000 and k=20

--- a/docs/uncertainty/VALIDATION.md
+++ b/docs/uncertainty/VALIDATION.md
@@ -883,3 +883,116 @@ member's reference is `h_det` regardless of `mm_i`).
 
     # Engine-level T̄ plumbing (real conduit velocity -> travel time):
     build/<dir>/bin/Debug/test_engine_1d_rom_lifecycle --gtest_filter='*TravelTime*'
+
+---
+
+# Quantile-reconstruction GEMM (PR H4)
+
+Measured 2026-08-16. Scratch benchmark (compiled standalone against the
+engine dylib, per this project's established calibration-sweep pattern —
+not a permanent `bench_*` target; the numbers below are the full record).
+`test_spectral_rom1d.cpp`'s new `QuantileGemm` suite and
+`test_2d_spectral_rom.cpp`'s new `QuantileGemm2D` suite (the latter newly
+registered in `tests/unit/engine/CMakeLists.txt` — found dormant, see §3)
+carry the correctness/equivalence/determinism assertions this section's
+numbers rest on.
+
+## 1. Problem
+
+`computeQuantiles()`'s ensemble reconstruction (`ΔH[t,i] = Σ_j P[j,t]·a[i,j]`
+over active modes, for every node/member pair) is an O(N·M·k) hand-rolled
+triple loop — the dominant ROM cost at large N (the roadmap's own perf
+table; CL-2d recorded it as the ~19% cap on that PR's own speedup).
+
+## 2. Fix
+
+`src/engine/uncertainty/RomQuantileGemm.hpp` (new, shared between the 1D and
+2D ROMs — the matrix layouts are identical): `reconstructEnsembleGemm()`
+compacts `P`/`a_ensemble` down to active-mode rows/columns only (preserving
+the exact masking semantics the hand-rolled loop had — including a mode that
+was active in the past and has since deactivated, which can still hold a
+small nonzero "frozen" coefficient that must stay excluded, not just an
+all-zero column), then computes the whole `[N × M]` reconstruction in one
+`cblas_dgemm` call (Apple's Accelerate framework — zero new dependency, per
+the checklist's own framing) or a portable compacted triple-loop fallback
+everywhere else (`OPENSWMM_HAVE_CBLAS`, set by CMake only when the Accelerate
+framework is found). Both `SpectralROM1D::computeQuantiles()` and 2D
+`SpectralROM::computeQuantiles()` gained a `rom_quantile_naive` config field
+(default `false`): when `true`, the original hand-rolled loop runs instead,
+kept byte-for-byte, for equivalence testing — both paths are always compiled
+in, never behind a build flag that would leave one of them untested.
+
+**1D kept its full `std::sort`; 2D switched to three `std::nth_element`
+selections — a deliberate, load-bearing difference, not an oversight.** PR
+H10's `sortedMemberValues()` hands PR H10's `exceedanceFraction()`/
+`gapModality()` the *whole* per-node row in ascending order — `gapModality()`
+specifically needs the gap between *every* pair of consecutive order
+statistics, which has no correct formulation without a full sort. The 2D ROM
+has no equivalent consumer (`parametric_tails`'s log-normal tail fit sums
+over all M members regardless of order — verified by reading the actual
+implementation, not assumed), so nth_element's full O(M) → 3×O(M) saving
+applies there cleanly. Implementing the checklist's literal "replace the
+per-node full sort with three nth_element selections" for 1D as well would
+have silently broken H10's shipped, tested modality flag — left as the naive
+path's `std::sort`, unaffected by `rom_quantile_naive` either way.
+
+## 3. Side finding: `test_2d_spectral_rom.cpp` was dormant
+
+49 tests (`SpectralROM`, `UncertaintyEnsemble`, `SpectralROMSpatial`,
+`DeviationForm2D`, `FiedlerDiagnostic` suites), present on disk since an
+early mechanical-port pass, never registered in
+`tests/unit/engine/CMakeLists.txt` — the exact same class of gap as PR-10's
+own coverage harness before P4, `test_spectral_rom1d.cpp` before H1, and
+(found the same session as this PR, on a different branch) PR11's
+final-boundary-stall tests. Registered it, since it's the natural home for
+this PR's 2D equivalence tests; **all 49 pre-existing tests passed
+immediately** against the current codebase with zero fixes needed — a strong
+independent correctness signal for the GEMM path (it now runs by default,
+so passing `DeviationForm2D.*`/`SpectralROMSpatial.*`/coupling-spread tests
+means GEMM reproduces the ROM's already-validated spread/median/coupling
+invariants, not just the new equivalence tests written for this PR
+specifically).
+
+## 4. Benchmark (measured, not a permanent target)
+
+**2D**: `test_corr_len_profile.cpp`'s own reference scale (N=70 structured
+mesh → 9,800 triangles — that file's own documented reason for 9.8k over the
+checklist's literal "≥20k": the Lanczos eigensolve at 20k/k=20 takes minutes
+on this machine, and the O(quantile) cost this PR targets scales linearly in
+N regardless of which N it's measured at).
+
+**1D**: the checklist names StormCity (8k nodes) explicitly. **StormCity is
+not available anywhere in this repository** — checked for a committed `.inp`,
+a fixture, and a generator script; none exist (it was evidently an
+external/local file used only in an earlier session, per `.memory`
+references to "StormCity real-network benchmark," never committed).
+Substituted with a synthetic 8,000-node chain of comparable scale — an
+honest substitution, documented here rather than silently presented as the
+named network.
+
+| Case | N | M | k | naive computeQuantiles() | GEMM computeQuantiles() | Speedup |
+|---|---|---|---|---|---|---|
+| 1D (synthetic chain, StormCity substitute) | 8,000 nodes | 50 | 30 | 54.2–54.7 ms | 4.34–4.35 ms | **12.5–12.6×** |
+| 2D (CL-2a reference mesh) | 9,800 triangles | 50 | 20 | 109.4–111.8 ms | 15.5–15.7 ms | **7.0–7.1×** |
+
+Each row is two independent runs of the same benchmark binary (not a single
+sample) — both cases reproduced within ~2% run-to-run. Both comfortably
+clear the checklist's own ≥3× gate on the quantile phase, with no tuning:
+these are the numbers `RomQuantileGemm.hpp`'s first working version produced.
+
+## 5. Reproduction
+
+    # Correctness: naive-vs-GEMM equivalence, mode-masking edge cases,
+    # invert-clamp interaction, run-to-run determinism (1D):
+    build/<dir>/bin/Debug/test_engine_spectral_rom1d --gtest_filter='QuantileGemm.*'
+
+    # Same, 2D (also exercises the newly-registered dormant suite, 49 tests):
+    ctest --test-dir build/<dir> -R test_engine_2d_spectral_rom
+
+    # H10's sortedMemberValues() full-sort contract, explicitly guarded under GEMM:
+    build/<dir>/bin/Debug/test_engine_spectral_rom1d \
+        --gtest_filter='QuantileGemm.SortedMemberValuesStaysFullySortedUnderGemm'
+
+The benchmark itself is not a checked-in target (compiled standalone per
+this project's calibration-sweep pattern); the numbers in §4 are the full
+record of what was measured.

--- a/docs/uncertainty/VALIDATION.md
+++ b/docs/uncertainty/VALIDATION.md
@@ -966,17 +966,24 @@ not available anywhere in this repository** — checked for a committed `.inp`,
 a fixture, and a generator script; none exist (it was evidently an
 external/local file used only in an earlier session, per `.memory`
 references to "StormCity real-network benchmark," never committed).
-Substituted with a synthetic 8,000-node chain of comparable scale — an
-honest substitution, documented here rather than silently presented as the
-named network.
+**Corrected to Bellinge** (real 1020-node sewer network, already the
+established production baseline for PR-10/H5/H11's own MC coverage
+validation — `tests/regression/test_rom_coverage_bellinge.cpp` — rather than
+a synthetic stand-in; an initial pass of this benchmark used a synthetic
+8,000-node chain before this correction, which is why the node count below
+differs from the checklist's literal "8k"). Driven through the real engine
+exactly as `test_rom_coverage_bellinge.cpp` does (same `[UNCERTAINTY] 1D
+MANNINGS_N 0.20` injection, same `REPORT_START_TIME`/rainfall-path fixes),
+stepped 1 simulated hour to reach a real, non-trivial ensemble state, then
+`computeQuantiles()` timed directly off the engine's own live `rom1d()`.
 
 | Case | N | M | k | naive computeQuantiles() | GEMM computeQuantiles() | Speedup |
 |---|---|---|---|---|---|---|
-| 1D (synthetic chain, StormCity substitute) | 8,000 nodes | 50 | 30 | 54.2–54.7 ms | 4.34–4.35 ms | **12.5–12.6×** |
+| 1D (Bellinge, real network) | 1,011 active nodes | 50 | 20 | 4.67–4.70 ms | 0.443–0.454 ms | **10.3–10.6×** |
 | 2D (CL-2a reference mesh) | 9,800 triangles | 50 | 20 | 109.4–111.8 ms | 15.5–15.7 ms | **7.0–7.1×** |
 
 Each row is two independent runs of the same benchmark binary (not a single
-sample) — both cases reproduced within ~2% run-to-run. Both comfortably
+sample) — both cases reproduced within ~3% run-to-run. Both comfortably
 clear the checklist's own ≥3× gate on the quantile phase, with no tuning:
 these are the numbers `RomQuantileGemm.hpp`'s first working version produced.
 

--- a/src/engine/2d/uncertainty/SpectralROM.cpp
+++ b/src/engine/2d/uncertainty/SpectralROM.cpp
@@ -712,6 +712,7 @@ void SpectralROM::computeQuantiles(const double* h_det, bool parametric_tails) {
 
     auto nt = static_cast<std::size_t>(n_tri);
     auto nk = static_cast<std::size_t>(n_kept);
+    auto M_sz = static_cast<std::size_t>(n_ensemble);
 
     // Compute quantile indices (into sorted n_ensemble values)
     // For M members, the p-th quantile index = floor(p * (M-1) + 0.5) (nearest rank)
@@ -720,52 +721,94 @@ void SpectralROM::computeQuantiles(const double* h_det, bool parametric_tails) {
     int idx50 = static_cast<int>(0.50 * (M - 1.0) + 0.5);
     int idx95 = std::min(n_ensemble - 1, static_cast<int>(0.95 * (M - 1.0) + 0.5));
 
-    for (std::size_t t = 0; t < nt; ++t) {
-        const double h_det_t = h_det[t];
-        // Reconstruct depth at cell t for all members: h_det + P·δa, floored at 0.
-        for (int i = 0; i < n_ensemble; ++i) {
-            const double* ai = &a_ensemble[static_cast<std::size_t>(i) * nk];
-            double h = h_det_t;
-            for (std::size_t j = 0; j < nk; ++j) {
-                if (!mode_active[j]) continue;
-                h += basis->P[j * nt + t] * ai[j];
+    // Log-normal parametric upper tail helper (order-independent: a plain
+    // sum over all M values, so it works identically whether the row is
+    // fully sorted, nth_element-selected, or in raw reconstruction order).
+    auto applyParametricTail = [&](const double* row, std::size_t t) {
+        constexpr double DRY_THRESH = 1.0e-4;
+        double sum_log = 0.0, sum_log2 = 0.0;
+        int n_wet = 0;
+        for (std::size_t i = 0; i < M_sz; ++i) {
+            double h = row[i];
+            if (h > DRY_THRESH) {
+                double lh = std::log(h);
+                sum_log  += lh;
+                sum_log2 += lh * lh;
+                ++n_wet;
             }
-            sort_buf_[static_cast<std::size_t>(i)] = std::max(h, 0.0);
         }
+        if (n_wet >= 4) {
+            double mu    = sum_log / n_wet;
+            double var   = std::max(sum_log2 / n_wet - mu * mu, 0.0);
+            double sigma = std::sqrt(var);
+            if (sigma > 1.0e-10) {
+                constexpr double Z95 = 1.6449;
+                q95[t] = std::exp(mu + Z95 * sigma);
+            }
+        }
+    };
 
-        // Sort to extract quantiles
-        std::sort(sort_buf_.begin(), sort_buf_.end());
-
-        q05[t] = sort_buf_[static_cast<std::size_t>(idx05)];
-        q50[t] = sort_buf_[static_cast<std::size_t>(idx50)];
-        q95[t] = sort_buf_[static_cast<std::size_t>(idx95)];
-
-        // Log-normal parametric upper tail: uses all M members to estimate
-        // distribution, reducing sensitivity to the single observed maximum
-        // when M is small.  Only replaces q95; q05/q50 remain sort-based.
-        if (parametric_tails) {
-            constexpr double DRY_THRESH = 1.0e-4;
-            double sum_log = 0.0, sum_log2 = 0.0;
-            int n_wet = 0;
+    if (rom_quantile_naive) {
+        for (std::size_t t = 0; t < nt; ++t) {
+            const double h_det_t = h_det[t];
+            // Reconstruct depth at cell t for all members: h_det + P·δa, floored at 0.
             for (int i = 0; i < n_ensemble; ++i) {
-                double h = sort_buf_[static_cast<std::size_t>(i)];
-                if (h > DRY_THRESH) {
-                    double lh = std::log(h);
-                    sum_log  += lh;
-                    sum_log2 += lh * lh;
-                    ++n_wet;
+                const double* ai = &a_ensemble[static_cast<std::size_t>(i) * nk];
+                double h = h_det_t;
+                for (std::size_t j = 0; j < nk; ++j) {
+                    if (!mode_active[j]) continue;
+                    h += basis->P[j * nt + t] * ai[j];
                 }
+                sort_buf_[static_cast<std::size_t>(i)] = std::max(h, 0.0);
             }
-            if (n_wet >= 4) {
-                double mu    = sum_log / n_wet;
-                double var   = std::max(sum_log2 / n_wet - mu * mu, 0.0);
-                double sigma = std::sqrt(var);
-                if (sigma > 1.0e-10) {
-                    constexpr double Z95 = 1.6449;
-                    q95[t] = std::exp(mu + Z95 * sigma);
-                }
-            }
+
+            // Sort to extract quantiles
+            std::sort(sort_buf_.begin(), sort_buf_.end());
+
+            q05[t] = sort_buf_[static_cast<std::size_t>(idx05)];
+            q50[t] = sort_buf_[static_cast<std::size_t>(idx50)];
+            q95[t] = sort_buf_[static_cast<std::size_t>(idx95)];
+
+            // Log-normal parametric upper tail: uses all M members to estimate
+            // distribution, reducing sensitivity to the single observed maximum
+            // when M is small.  Only replaces q95; q05/q50 remain sort-based.
+            if (parametric_tails) applyParametricTail(sort_buf_.data(), t);
         }
+        return;
+    }
+
+    // PR H4: GEMM reconstruction (RomQuantileGemm.hpp) fills recon_buf_ with
+    // the raw modal delta Σ_j P[j,t]·a[i,j] (active modes only, same masking
+    // as the naive loop above) for every (cell, member) pair in one call,
+    // instead of the O(nt*M*nk) hand-rolled loop. h_det + floor-at-0 is
+    // applied per element below, matching the naive path's clamp exactly.
+    recon_buf_.assign(nt * M_sz, 0.0);
+    openswmm::uncertainty::reconstructEnsembleGemm(
+        basis->P.data(), a_ensemble.data(), mode_active,
+        n_tri, n_kept, n_ensemble, recon_buf_.data(),
+        gemm_P_active_, gemm_A_active_);
+
+    for (std::size_t t = 0; t < nt; ++t) {
+        double* row = &recon_buf_[t * M_sz];
+        const double h_det_t = h_det[t];
+        for (std::size_t i = 0; i < M_sz; ++i)
+            row[i] = std::max(h_det_t + row[i], 0.0);
+
+        // Three independent std::nth_element selections instead of a full
+        // sort: no downstream consumer needs the whole row in sorted order
+        // (unlike SpectralROM1D::computeQuantiles(), whose sortedMemberValues()
+        // feeds PR H10's threshold/modality machinery -- see RomQuantileGemm.hpp
+        // and SpectralROM1D.cpp for that distinction). Each call's result is
+        // correct regardless of what the previous calls left the rest of the
+        // row looking like.
+        std::nth_element(row, row + idx05, row + M_sz);
+        q05[t] = row[static_cast<std::size_t>(idx05)];
+        std::nth_element(row, row + idx50, row + M_sz);
+        q50[t] = row[static_cast<std::size_t>(idx50)];
+        std::nth_element(row, row + idx95, row + M_sz);
+        q95[t] = row[static_cast<std::size_t>(idx95)];
+
+        if (parametric_tails) applyParametricTail(row, t);
     }
 }
 

--- a/src/engine/2d/uncertainty/SpectralROM.hpp
+++ b/src/engine/2d/uncertainty/SpectralROM.hpp
@@ -38,6 +38,7 @@
 #include "../coupling/NodeCoupling.hpp"
 #include "SpatialUncertaintyField.hpp"
 #include "uncertainty/UncertaintyTypes.hpp"
+#include "uncertainty/RomQuantileGemm.hpp"
 #include <vector>
 #include <cstddef>
 #include <cstdint>
@@ -83,6 +84,16 @@ struct SpectralROM {
     uint64_t sample_seed = 42;
 
     double mode_drop_threshold = 1.0e-10; ///< Drop mode j when E_j < threshold AND rain forcing < threshold.
+
+    // -------------------------------------------------------------------------
+    // PR H4 — quantile-reconstruction GEMM. Debug/equivalence-testing knob:
+    // when true, computeQuantiles() uses the original hand-rolled per-cell
+    // reconstruction + full sort instead of reconstructEnsembleGemm()
+    // (RomQuantileGemm.hpp) + std::nth_element selection. Both paths always
+    // compiled in. Default false = GEMM + nth_element (or the portable
+    // fallback where OPENSWMM_HAVE_CBLAS is not defined).
+    // -------------------------------------------------------------------------
+    bool rom_quantile_naive = false;
 
     // -------------------------------------------------------------------------
     // State (set by initialize() and seed())
@@ -472,7 +483,15 @@ private:
 
     std::vector<double> h_work_;      ///< n_tri: scratch for reconstruction.
     std::vector<double> h_det_last_;  ///< n_tri: deterministic depth from the last advance()/seed().
-    std::vector<double> sort_buf_;    ///< n_ensemble: per-cell sort workspace.
+    std::vector<double> sort_buf_;    ///< n_ensemble: per-cell sort/selection workspace.
+
+    // PR H4 — GEMM reconstruction (RomQuantileGemm.hpp). recon_buf_ is
+    // n_tri*n_ensemble, cell-major (recon_buf_[t*M+i]); gemm_*_active_ are
+    // resized internally to k_active*n_tri / n_ensemble*k_active, reused
+    // across calls.
+    std::vector<double> recon_buf_;
+    std::vector<double> gemm_P_active_;
+    std::vector<double> gemm_A_active_;
     std::vector<double> keff_modes_;  ///< n_kept: per-mode K_eff (Rayleigh quotient, scalar path).
     std::vector<double> mode_energy_; ///< n_kept: E_j = mean_i(a²_{i,j}), recomputed each advance().
     std::vector<double> h_weight_;    ///< n_tri: depth-based cell weights (h/h̄)^(5/3) for keff.

--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -181,6 +181,26 @@ elseif(APPLE)
     # dl is part of libSystem on macOS
 endif()
 
+# ---- CBLAS (PR H4 — quantile-reconstruction GEMM) ----
+# Apple's Accelerate framework ships a full CBLAS implementation as part of
+# the base OS (zero new deps, per the H4 spec) and is the only platform this
+# PR wires up directly. Elsewhere, SpectralROM1D/SpectralROM fall back to a
+# portable triple-loop GEMM (OPENSWMM_HAVE_CBLAS undefined) -- correct
+# everywhere, just not BLAS-accelerated off Apple. Adding a system BLAS
+# (OpenBLAS/MKL) dependency for Linux/Windows is explicitly out of scope here.
+if(APPLE)
+    find_library(ACCELERATE_FRAMEWORK Accelerate)
+    if(ACCELERATE_FRAMEWORK)
+        target_link_libraries(openswmm_engine PRIVATE ${ACCELERATE_FRAMEWORK})
+        target_compile_definitions(openswmm_engine PRIVATE OPENSWMM_HAVE_CBLAS)
+        message(STATUS "OpenSWMM Engine: CBLAS via Accelerate framework enabled (quantile-reconstruction GEMM)")
+    else()
+        message(STATUS "OpenSWMM Engine: Accelerate framework not found — quantile reconstruction uses the portable fallback")
+    endif()
+else()
+    message(STATUS "OpenSWMM Engine: no CBLAS wired on this platform — quantile reconstruction uses the portable fallback")
+endif()
+
 # ---- SIMD compiler flags ----
 option(OPENSWMM_FORCE_SCALAR "Disable SIMD intrinsics; use scalar fallback only" OFF)
 

--- a/src/engine/uncertainty/RomQuantileGemm.hpp
+++ b/src/engine/uncertainty/RomQuantileGemm.hpp
@@ -1,0 +1,153 @@
+/**
+ * @file RomQuantileGemm.hpp
+ * @brief PR H4 — GEMM-accelerated ensemble reconstruction, shared between
+ *        SpectralROM1D::computeQuantiles() and 2D SpectralROM::computeQuantiles().
+ *
+ * @details Both ROMs reconstruct the full ensemble depth/head field the same
+ *          way: `ΔH[t,i] = Σ_j P[j,t]·a_ensemble[i,j]` over active modes j,
+ *          for every (node t, member i) pair -- an O(N·M·k) hand-rolled
+ *          triple loop that dominates ROM cost at large N (the roadmap's own
+ *          perf table; CL-2d recorded it as the ~19% cap on that PR's own
+ *          speedup). `P` (n_kept × n_nodes row-major) and `a_ensemble`
+ *          (n_ensemble × n_kept row-major) are already laid out for a single
+ *          `cblas_dgemm` call with no transposition copies:
+ *
+ *              recon (n_nodes × n_ensemble, node-major)
+ *                  = P_active^T (n_nodes × k_active) · A_active^T (k_active × n_ensemble)
+ *
+ *          computed via `cblas_dgemm(..., TransA=Trans, TransB=Trans, ...)`
+ *          directly on the (compacted) row-major buffers -- BLAS's transpose
+ *          flags avoid a physical transpose, and the result lands exactly in
+ *          the node-major layout `computeQuantiles()`'s existing sort/select
+ *          loop already expects (recon[t*M+i]).
+ *
+ *          ACTIVE-MODE MASKING (load-bearing, not an optimization detail):
+ *          the pre-GEMM loops in both ROMs skip inactive modes in
+ *          RECONSTRUCTION, not merely in advance()'s ODE update
+ *          (`if (!mode_active[j]) continue;`). A mode that was active in the
+ *          past and has since deactivated can still hold a small nonzero
+ *          "frozen" `a_ensemble` coefficient (advance() simply stops
+ *          updating it once inactive; it does not zero it), so a naive
+ *          full-k GEMM over every mode would silently reintroduce those
+ *          frozen contributions and NOT match the pre-GEMM behavior. This
+ *          function compacts `P`/`a_ensemble` down to active-mode rows/
+ *          columns first -- same masking semantics, same result -- rather
+ *          than zeroing anything in place (P is basis-owned and often const;
+ *          a_ensemble is per-member and would need an O(M·k) sweep every
+ *          call either way, so compaction is no more expensive and touches
+ *          neither source buffer).
+ *
+ *          Apple's Accelerate framework provides a complete CBLAS
+ *          implementation as part of the base OS (`OPENSWMM_HAVE_CBLAS`,
+ *          set by CMake when found -- zero new dependency). Everywhere else
+ *          this falls back to a portable compacted triple loop: correct
+ *          everywhere, BLAS-accelerated only where Accelerate is linked.
+ *
+ * @ingroup engine_uncertainty
+ */
+
+#ifndef OPENSWMM_ENGINE_UNCERTAINTY_ROM_QUANTILE_GEMM_HPP
+#define OPENSWMM_ENGINE_UNCERTAINTY_ROM_QUANTILE_GEMM_HPP
+
+#include <algorithm>
+#include <cstddef>
+#include <vector>
+
+#if defined(OPENSWMM_HAVE_CBLAS)
+#include <Accelerate/Accelerate.h>
+#endif
+
+namespace openswmm::uncertainty {
+
+/**
+ * @brief Reconstruct the full ensemble field ΔH = A·P (active modes only),
+ *        written node-major to match the existing per-node quantile loop.
+ *
+ * @param P            Full mode matrix, n_kept × n_nodes row-major
+ *                      (`P[j*n_nodes+t]`) -- GraphEigenBasis::P / MeshEigenBasis::P.
+ * @param a_ensemble   Full ensemble coefficient matrix, n_ensemble × n_kept
+ *                      row-major (`a_ensemble[i*n_kept+j]`).
+ * @param mode_active  Length n_kept; only active modes contribute (matches
+ *                      the pre-GEMM loops' masking exactly -- see file doc).
+ * @param n_nodes      Number of active nodes / triangles (N).
+ * @param n_kept       Total retained modes (k).
+ * @param n_ensemble   Ensemble size (M).
+ * @param recon        Output, length n_nodes*n_ensemble, node-major
+ *                      (`recon[t*n_ensemble+i]`). OVERWRITTEN, not accumulated.
+ * @param P_active_buf Scratch, resized internally to k_active*n_nodes.
+ *                      Caller-owned so repeated calls reuse the allocation.
+ * @param A_active_buf Scratch, resized internally to n_ensemble*k_active.
+ *                      Caller-owned so repeated calls reuse the allocation.
+ */
+inline void reconstructEnsembleGemm(const double* P, const double* a_ensemble,
+                                     const std::vector<bool>& mode_active,
+                                     int n_nodes, int n_kept, int n_ensemble,
+                                     double* recon,
+                                     std::vector<double>& P_active_buf,
+                                     std::vector<double>& A_active_buf) noexcept {
+    const auto nn = static_cast<std::size_t>(n_nodes);
+    const auto nk = static_cast<std::size_t>(n_kept);
+    const auto M  = static_cast<std::size_t>(n_ensemble);
+
+    std::vector<int> active_modes;
+    active_modes.reserve(nk);
+    for (std::size_t j = 0; j < nk; ++j)
+        if (mode_active[j]) active_modes.push_back(static_cast<int>(j));
+    const std::size_t k_active = active_modes.size();
+
+    if (k_active == 0 || nn == 0 || M == 0) {
+        std::fill(recon, recon + nn * M, 0.0);
+        return;
+    }
+
+    P_active_buf.resize(k_active * nn);
+    for (std::size_t r = 0; r < k_active; ++r) {
+        const double* src = &P[static_cast<std::size_t>(active_modes[r]) * nn];
+        std::copy(src, src + nn, &P_active_buf[r * nn]);
+    }
+    A_active_buf.resize(M * k_active);
+    for (std::size_t i = 0; i < M; ++i) {
+        const double* row = &a_ensemble[i * nk];
+        double* dst = &A_active_buf[i * k_active];
+        for (std::size_t r = 0; r < k_active; ++r)
+            dst[r] = row[static_cast<std::size_t>(active_modes[r])];
+    }
+
+#if defined(OPENSWMM_HAVE_CBLAS)
+    // The legacy (non-ILP64) CBLAS interface is deprecated but still fully
+    // supported on every macOS version this project targets; opting into
+    // ACCELERATE_NEW_LAPACK project-wide is a separate, unrelated decision
+    // (it also touches LAPACK integer width, which nothing here uses), so
+    // this silences just the one known-fine deprecation instead.
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+    cblas_dgemm(CblasRowMajor, CblasTrans, CblasTrans,
+                static_cast<int>(nn), static_cast<int>(M), static_cast<int>(k_active),
+                1.0, P_active_buf.data(), static_cast<int>(nn),
+                A_active_buf.data(), static_cast<int>(k_active),
+                0.0, recon, static_cast<int>(M));
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+#else
+    // Portable fallback: same access pattern as the pre-GEMM hand-rolled
+    // loop (mode-outer, node-middle, member-inner), just over the compacted
+    // active-only matrices instead of a masked full-k sweep.
+    std::fill(recon, recon + nn * M, 0.0);
+    for (std::size_t r = 0; r < k_active; ++r) {
+        const double* Pr = &P_active_buf[r * nn];
+        for (std::size_t t = 0; t < nn; ++t) {
+            const double pjt = Pr[t];
+            double* row = &recon[t * M];
+            for (std::size_t i = 0; i < M; ++i)
+                row[i] += pjt * A_active_buf[i * k_active + r];
+        }
+    }
+#endif
+}
+
+}  // namespace openswmm::uncertainty
+
+#endif  // OPENSWMM_ENGINE_UNCERTAINTY_ROM_QUANTILE_GEMM_HPP

--- a/src/engine/uncertainty/SpectralROM1D.cpp
+++ b/src/engine/uncertainty/SpectralROM1D.cpp
@@ -590,19 +590,32 @@ void SpectralROM1D::computeQuantiles(const double* h_det_active,
                          static_cast<int>(0.95 * (static_cast<double>(M) - 1.0) + 0.5));
 
     // Recon buffer: H[node, member] = h_det[node] + Σ_j P[j,node]·δa[member,j]
-    // (nn × M). Computed as one node-major pass per active mode; intermediate
-    // storage is recon_buf_ (row-major: row = node).
+    // (nn × M), row-major: row = node. PR H4: the reconstruction (this
+    // buffer's fill) is the O(N·M·k) term that dominates at large N; below
+    // is either the original hand-rolled loop (rom_quantile_naive == true,
+    // kept byte-for-byte as the equivalence-test baseline) or
+    // reconstructEnsembleGemm() (RomQuantileGemm.hpp), which computes the
+    // identical active-mode-masked sum via cblas_dgemm (or a portable
+    // fallback) in one call. Everything after this block -- phase
+    // reference selection, sort, quantile extraction -- is unchanged by
+    // and unaware of which path filled recon_buf_.
     recon_buf_.assign(nn * M, 0.0);
 
-    for (std::size_t j = 0; j < nk; ++j) {
-        if (!mode_active[j]) continue;
-        const double* Pj = &basis->P[j * nn];       // P[:,j]: length nn
-        for (std::size_t t = 0; t < nn; ++t) {
-            double pjt = Pj[t];
-            double* row = &recon_buf_[t * M];        // H[t,:]: length M
-            for (std::size_t i = 0; i < M; ++i)
-                row[i] += pjt * a_ensemble[i * nk + j];
+    if (rom_quantile_naive) {
+        for (std::size_t j = 0; j < nk; ++j) {
+            if (!mode_active[j]) continue;
+            const double* Pj = &basis->P[j * nn];       // P[:,j]: length nn
+            for (std::size_t t = 0; t < nn; ++t) {
+                double pjt = Pj[t];
+                double* row = &recon_buf_[t * M];        // H[t,:]: length M
+                for (std::size_t i = 0; i < M; ++i)
+                    row[i] += pjt * a_ensemble[i * nk + j];
+            }
         }
+    } else {
+        reconstructEnsembleGemm(basis->P.data(), a_ensemble.data(), mode_active,
+                                n_nodes, n_kept, n_ensemble, recon_buf_.data(),
+                                gemm_P_active_, gemm_A_active_);
     }
 
     // PR H11: per-member phase coordinate. Active only when a travel-time

--- a/src/engine/uncertainty/SpectralROM1D.hpp
+++ b/src/engine/uncertainty/SpectralROM1D.hpp
@@ -39,6 +39,7 @@
 #include "UncertaintyTypes.hpp"
 #include "SoftSpatialField.hpp"
 #include "RomPhaseCoordinate.hpp"
+#include "RomQuantileGemm.hpp"
 #include <vector>
 #include <cstddef>
 #include <cstdint>
@@ -110,6 +111,17 @@ struct SpectralROM1D {
     // bit-identical to before this PR.
     // -------------------------------------------------------------------------
     PhaseConfig phase_cfg;
+
+    // -------------------------------------------------------------------------
+    // PR H4 — quantile-reconstruction GEMM. Debug/equivalence-testing knob:
+    // when true, computeQuantiles() uses the original hand-rolled O(N*M*k)
+    // reconstruction loop instead of reconstructEnsembleGemm() (RomQuantileGemm.hpp).
+    // Both paths are always compiled in; this never disables the mode-active
+    // masking or the sort/quantile-extraction step, which are unaffected by
+    // this flag and identical either way. Default false = GEMM path (or the
+    // portable fallback where OPENSWMM_HAVE_CBLAS is not defined).
+    // -------------------------------------------------------------------------
+    bool rom_quantile_naive = false;
 
     // -------------------------------------------------------------------------
     // State (set by initialize() and seed())
@@ -566,6 +578,11 @@ private:
 
     // PR 5 — vectorized computeQuantiles scratch buffer (node-major: nn × M)
     std::vector<double> recon_buf_;
+
+    // PR H4 — GEMM reconstruction scratch (RomQuantileGemm.hpp); resized to
+    // k_active*n_nodes / n_ensemble*k_active internally, reused across calls.
+    std::vector<double> gemm_P_active_;
+    std::vector<double> gemm_A_active_;
 
     // PR H11 — per-member phase coordinate
     /// Per-active-node travel time T̄(x) (s), length n_nodes; empty when

--- a/tests/unit/engine/CMakeLists.txt
+++ b/tests/unit/engine/CMakeLists.txt
@@ -250,6 +250,12 @@ if(OPENSWMM_BUILD_2D)
     # bit-identical with the ensemble on or off.
     add_gtest_unit(test_engine_2d_rom_nonintrusive test_2d_rom_nonintrusive.cpp)
 
+    # Unit tests for the 2D SpectralROM itself (linear ensemble ROM math).
+    # Present on disk since an early mechanical-port pass but never wired
+    # into this file until PR H4 needed a home for its GEMM-vs-naive
+    # quantile-reconstruction equivalence tests -- found dormant, registered.
+    add_gtest_unit(test_engine_2d_spectral_rom test_2d_spectral_rom.cpp)
+
     # SurfaceRouter2D's wiring of the calibrated reduced operator: production
     # default vs rom_legacy_operator fallback, and open-boundary grounding
     # reachable through the router's own boundary_ (not just at the

--- a/tests/unit/engine/test_2d_spectral_rom.cpp
+++ b/tests/unit/engine/test_2d_spectral_rom.cpp
@@ -1778,3 +1778,135 @@ TEST(FiedlerDiagnostic, CouplingAnnotation2DSide) {
     const int low_cell_idx = fd.rank[static_cast<std::size_t>(f.basis.n_triangles - 1)];
     EXPECT_LE(fd.grad[static_cast<std::size_t>(low_cell_idx)], bottleneck_score);
 }
+
+// ============================================================================
+// PR H4 — quantile-reconstruction GEMM. computeQuantiles()'s reconstruction
+// (recon_buf_ fill) now goes through reconstructEnsembleGemm()
+// (RomQuantileGemm.hpp, cblas_dgemm or a portable fallback) by default, with
+// three independent std::nth_element selections replacing the full sort --
+// unlike the 1D ROM, nothing here needs the whole per-cell member row in
+// sorted order (parametric_tails sums over all M values regardless of
+// order), so 2D gets the full nth_element speedup. rom_quantile_naive=true
+// keeps the original hand-rolled loop + full sort available for comparison.
+// ============================================================================
+
+namespace {
+void expectRelClose2D(double a, double b, double rel_tol, const char* what) {
+    const double scale = std::max({std::fabs(a), std::fabs(b), 1.0});
+    EXPECT_NEAR(a, b, rel_tol * scale) << what;
+}
+}  // namespace
+
+TEST(QuantileGemm2D, NaiveMatchesGemm) {
+    // N=6 -> 72 triangles, enough modes requested to exercise a real
+    // active/inactive mode split.
+    Fixture f(/*N=*/6, /*k=*/10, /*M=*/30, /*m_pert=*/0.25, /*r_pert=*/0.25);
+    const int n = f.rom.n_tri;
+
+    std::vector<double> h0(static_cast<std::size_t>(n));
+    for (int t = 0; t < n; ++t)
+        h0[static_cast<std::size_t>(t)] = 0.08 + 0.004 * (t % 17);
+    f.rom.seed(h0.data());
+
+    std::vector<double> rain(static_cast<std::size_t>(n));
+    std::vector<double> h_det = h0;
+    for (int step = 0; step < 40; ++step) {
+        const double phase = 0.08 * step;
+        for (int t = 0; t < n; ++t)
+            rain[static_cast<std::size_t>(t)] =
+                1.0e-5 * (1.0 + std::sin(phase + 0.3 * t));
+        f.rom.advance(30.0, 6.0, rain.data(), nullptr, h_det.data());
+    }
+
+    // Deliberately deactivate a couple of modes with a frozen nonzero
+    // coefficient left behind -- same edge case as the 1D equivalence test
+    // (RomQuantileGemm.hpp's active-mode compaction must exclude it).
+    ASSERT_GE(f.rom.n_kept, 4);
+    f.rom.mode_active[1] = false;
+    f.rom.mode_active[2] = false;
+    for (int i = 0; i < f.rom.n_ensemble; ++i)
+        f.rom.a_ensemble[static_cast<std::size_t>(i) * static_cast<std::size_t>(f.rom.n_kept) + 1] =
+            0.0021 * (i + 1);
+
+    for (bool parametric : {false, true}) {
+        f.rom.rom_quantile_naive = true;
+        f.rom.computeQuantiles(h_det.data(), parametric);
+        const std::vector<double> q05_naive = f.rom.q05;
+        const std::vector<double> q50_naive = f.rom.q50;
+        const std::vector<double> q95_naive = f.rom.q95;
+
+        f.rom.rom_quantile_naive = false;
+        f.rom.computeQuantiles(h_det.data(), parametric);
+
+        // q05/q50 are always plain sort-/nth_element-selected values -- an
+        // exact selection with no arithmetic on top, so GEMM's different
+        // summation order (checklist: "1e-12 relative, not bit-exact")
+        // survives untouched into them. q95 under parametric_tails routes
+        // through log()/exp() over all M members first, which measurably
+        // (~4-5x observed) amplifies that same tiny reconstruction-level
+        // difference -- a real, expected property of the nonlinear formula,
+        // not a GEMM defect, so it gets its own looser (still tight) bound.
+        for (int t = 0; t < n; ++t) {
+            const auto ut = static_cast<std::size_t>(t);
+            SCOPED_TRACE(::testing::Message()
+                        << "cell " << t << " parametric_tails=" << parametric);
+            expectRelClose2D(f.rom.q05[ut], q05_naive[ut], 1e-12, "q05");
+            expectRelClose2D(f.rom.q50[ut], q50_naive[ut], 1e-12, "q50");
+            expectRelClose2D(f.rom.q95[ut], q95_naive[ut], parametric ? 1e-9 : 1e-12, "q95");
+        }
+    }
+}
+
+TEST(QuantileGemm2D, GemmIsRunToRunDeterministic) {
+    // Same concern as the 1D companion test: cblas_dgemm via Accelerate must
+    // give bit-identical output across repeated calls on the same input, not
+    // just "close" -- no thread-scheduling nondeterminism in the reduction.
+    Fixture f(/*N=*/5, /*k=*/8, /*M=*/25);
+    ASSERT_FALSE(f.rom.rom_quantile_naive);
+    const int n = f.rom.n_tri;
+
+    std::vector<double> h0(static_cast<std::size_t>(n));
+    for (int t = 0; t < n; ++t) h0[static_cast<std::size_t>(t)] = 0.06 + 0.003 * (t % 13);
+    f.rom.seed(h0.data());
+    std::vector<double> rain(static_cast<std::size_t>(n), 1.0e-5);
+    std::vector<double> h_det = h0;
+    for (int step = 0; step < 15; ++step)
+        f.rom.advance(30.0, 5.0, rain.data(), nullptr, h_det.data());
+
+    f.rom.computeQuantiles(h_det.data());
+    const std::vector<double> q05_1 = f.rom.q05, q50_1 = f.rom.q50, q95_1 = f.rom.q95;
+
+    for (int rep = 0; rep < 5; ++rep) {
+        f.rom.computeQuantiles(h_det.data());
+        for (int t = 0; t < n; ++t) {
+            const auto ut = static_cast<std::size_t>(t);
+            EXPECT_EQ(f.rom.q05[ut], q05_1[ut]) << "rep " << rep << " cell " << t << " q05";
+            EXPECT_EQ(f.rom.q50[ut], q50_1[ut]) << "rep " << rep << " cell " << t << " q50";
+            EXPECT_EQ(f.rom.q95[ut], q95_1[ut]) << "rep " << rep << " cell " << t << " q95";
+        }
+    }
+}
+
+TEST(QuantileGemm2D, GemmIsDefaultAndOrderPreserved) {
+    // Sanity companion to the equivalence test above: with no flag set,
+    // computeQuantiles() must already be on the GEMM path, and quantile
+    // ordering must hold regardless.
+    Fixture f;
+    ASSERT_FALSE(f.rom.rom_quantile_naive) << "GEMM must be the default path";
+    const int n = f.rom.n_tri;
+
+    std::vector<double> h(static_cast<std::size_t>(n));
+    for (int t = 0; t < n; ++t) h[static_cast<std::size_t>(t)] = 0.1 + 0.01 * t;
+    f.rom.seed(h.data());
+
+    std::vector<double> rain(static_cast<std::size_t>(n), 1e-5);
+    for (int step = 0; step < 10; ++step)
+        f.rom.advance(30.0, 5.0, rain.data(), nullptr, h.data());
+    f.rom.computeQuantiles(h.data());
+
+    for (int t = 0; t < n; ++t) {
+        const auto ut = static_cast<std::size_t>(t);
+        EXPECT_LE(f.rom.q05[ut], f.rom.q50[ut]) << "cell " << t;
+        EXPECT_LE(f.rom.q50[ut], f.rom.q95[ut]) << "cell " << t;
+    }
+}

--- a/tests/unit/engine/test_spectral_rom1d.cpp
+++ b/tests/unit/engine/test_spectral_rom1d.cpp
@@ -2866,3 +2866,230 @@ TEST(PhaseCoordinate, HistoryShorterThanTauDegradesGracefully) {
         << "narrower than the mature band (width=" << width_mature << "), "
         << "not exploding from the lookback clamp";
 }
+
+// ============================================================================
+// PR H4 — quantile-reconstruction GEMM. computeQuantiles()'s reconstruction
+// step (recon_buf_ fill) now goes through reconstructEnsembleGemm()
+// (RomQuantileGemm.hpp, cblas_dgemm or a portable fallback) by default;
+// rom_quantile_naive=true keeps the original hand-rolled loop available for
+// direct comparison. computeQuantiles() still does a full std::sort per
+// node either way (H10's sortedMemberValues() needs the whole row in
+// ascending order for its gap-statistic modality check -- see
+// RomQuantileGemm.hpp's file doc for why 1D did not switch to nth_element
+// the way the 2D ROM did).
+// ============================================================================
+
+namespace {
+// Relative-tolerance comparison (GEMM's internal summation order is not
+// guaranteed to match the naive left-to-right accumulation bit-for-bit).
+void expectRelClose(double a, double b, double rel_tol, const char* what) {
+    const double scale = std::max({std::fabs(a), std::fabs(b), 1.0});
+    EXPECT_NEAR(a, b, rel_tol * scale) << what;
+}
+}  // namespace
+
+TEST(QuantileGemm, GemmIsRunToRunDeterministic) {
+    // The checklist's own determinism requirement ("TwoRunsAreIdentical must
+    // stay green -- GEMM is deterministic run-to-run") names a full-engine
+    // test that no longer exists under that name anywhere in this tree
+    // (grepped; not present -- apparently dropped somewhere across the
+    // marcher port, unrelated to this PR). The underlying concern is real
+    // and specific to this PR though: does cblas_dgemm (Accelerate, possibly
+    // internally multithreaded) give bit-identical output across repeated
+    // calls on the SAME input, or can thread-scheduling nondeterminism leak
+    // into the reduction order? Verified directly here instead.
+    const int N = 22, M = 32, K = 7;
+    GraphEigenBasis basis;
+    CsrGraph L = make_chain_laplacian(N);
+    ASSERT_TRUE(basis.build(L, K));
+
+    SpectralROM1D rom;
+    rom.basis = &basis;
+    rom.n_ensemble = M;
+    rom.mannings_pert = 0.25;
+    rom.runoff_pert   = 0.15;
+    rom.initialize();
+    ASSERT_FALSE(rom.rom_quantile_naive);
+
+    std::vector<double> h0(static_cast<std::size_t>(N));
+    for (int i = 0; i < N; ++i) {
+        double dx = i - N / 3.0;
+        h0[static_cast<std::size_t>(i)] = 0.1 * std::exp(-0.5 * dx * dx / (N / 6.0 * N / 6.0));
+    }
+    rom.seed(h0.data());
+    std::vector<double> h_det = h0;
+    std::vector<double> runoff(static_cast<std::size_t>(N), 1.0e-5);
+    for (int step = 0; step < 25; ++step)
+        rom.advance(20.0, 0.1, h_det.data(), runoff.data());
+
+    rom.computeQuantiles(h_det.data(), nullptr);
+    const std::vector<double> q05_1 = rom.q05, q50_1 = rom.q50, q95_1 = rom.q95;
+
+    // Repeat computeQuantiles() on the SAME (unmodified) state several times.
+    for (int rep = 0; rep < 5; ++rep) {
+        rom.computeQuantiles(h_det.data(), nullptr);
+        for (int t = 0; t < rom.n_nodes; ++t) {
+            const auto ut = static_cast<std::size_t>(t);
+            EXPECT_EQ(rom.q05[ut], q05_1[ut]) << "rep " << rep << " node " << t << " q05";
+            EXPECT_EQ(rom.q50[ut], q50_1[ut]) << "rep " << rep << " node " << t << " q50";
+            EXPECT_EQ(rom.q95[ut], q95_1[ut]) << "rep " << rep << " node " << t << " q95";
+        }
+    }
+}
+
+TEST(QuantileGemm, NaiveMatchesGemm1D) {
+    // A network/ensemble large enough to exercise multiple active AND
+    // multiple deliberately-inactive modes in the same call -- the
+    // active-mode compaction is the one place GEMM equivalence could
+    // silently go wrong.
+    const int N = 25, M = 35, K = 8;
+    GraphEigenBasis basis;
+    CsrGraph L = make_chain_laplacian(N);
+    ASSERT_TRUE(basis.build(L, K));
+
+    SpectralROM1D rom;
+    rom.basis = &basis;
+    rom.n_ensemble = M;
+    rom.mannings_pert = 0.25;
+    rom.runoff_pert   = 0.25;
+    rom.initialize();
+
+    std::vector<double> h0(static_cast<std::size_t>(N));
+    for (int i = 0; i < N; ++i) {
+        double dx = i - N / 3.0;
+        h0[static_cast<std::size_t>(i)] =
+            0.15 * std::exp(-0.5 * dx * dx / (N / 6.0 * N / 6.0));
+    }
+    rom.seed(h0.data());
+
+    std::vector<double> h_det(static_cast<std::size_t>(N));
+    std::vector<double> runoff(static_cast<std::size_t>(N));
+    for (int step = 0; step < 60; ++step) {
+        const double phase = 0.07 * step;
+        for (int i = 0; i < N; ++i) {
+            h_det[static_cast<std::size_t>(i)] =
+                h0[static_cast<std::size_t>(i)] * (1.0 + 0.4 * std::sin(phase + 0.35 * i));
+            runoff[static_cast<std::size_t>(i)] =
+                1.0e-5 * (1.0 + std::cos(phase + 0.5 * i));
+        }
+        rom.advance(20.0, 0.12, h_det.data(), runoff.data());
+    }
+
+    // Force a real "some modes inactive" scenario, INCLUDING a frozen
+    // nonzero coefficient on a deactivated mode -- a mode that was active in
+    // the past and has since dropped out keeps whatever a_ensemble value it
+    // last had (advance() simply stops updating it); both the naive mask
+    // and the GEMM compaction must exclude it identically.
+    ASSERT_GE(rom.n_kept, 4);
+    rom.mode_active[1] = false;
+    rom.mode_active[3] = false;
+    for (int i = 0; i < M; ++i)
+        rom.a_ensemble[static_cast<std::size_t>(i) * static_cast<std::size_t>(rom.n_kept) + 1] =
+            0.0037 * (i + 1);  // frozen nonzero on an inactive mode -- must be excluded either way
+
+    rom.rom_quantile_naive = true;
+    rom.computeQuantiles(h_det.data(), nullptr);
+    const std::vector<double> q05_naive = rom.q05;
+    const std::vector<double> q50_naive = rom.q50;
+    const std::vector<double> q95_naive = rom.q95;
+
+    rom.rom_quantile_naive = false;
+    rom.computeQuantiles(h_det.data(), nullptr);
+
+    for (int t = 0; t < rom.n_nodes; ++t) {
+        const auto ut = static_cast<std::size_t>(t);
+        expectRelClose(rom.q05[ut], q05_naive[ut], 1e-12, "q05");
+        expectRelClose(rom.q50[ut], q50_naive[ut], 1e-12, "q50");
+        expectRelClose(rom.q95[ut], q95_naive[ut], 1e-12, "q95");
+    }
+}
+
+TEST(QuantileGemm, NaiveMatchesGemm1DWithInvertClamp) {
+    // Same fixture shape, but with invert_active clamping engaged (a
+    // separate branch in computeQuantiles() applied identically after
+    // either reconstruction path).
+    const int N = 20, M = 30, K = 6;
+    GraphEigenBasis basis;
+    CsrGraph L = make_chain_laplacian(N);
+    ASSERT_TRUE(basis.build(L, K));
+
+    SpectralROM1D rom;
+    rom.basis = &basis;
+    rom.n_ensemble = M;
+    rom.mannings_pert = 0.30;
+    rom.runoff_pert   = 0.0;
+    rom.initialize();
+
+    std::vector<double> h0(static_cast<std::size_t>(N));
+    std::vector<double> invert(static_cast<std::size_t>(N));
+    for (int i = 0; i < N; ++i) {
+        double dx = i - N / 4.0;
+        h0[static_cast<std::size_t>(i)] =
+            0.05 * std::exp(-0.5 * dx * dx / (N / 8.0 * N / 8.0));
+        invert[static_cast<std::size_t>(i)] = 0.02;  // above 0 so clamping actually engages
+    }
+    rom.seed(h0.data());
+
+    std::vector<double> h_det = h0;
+    std::vector<double> runoff(static_cast<std::size_t>(N), 0.0);
+    for (int step = 0; step < 40; ++step)
+        rom.advance(15.0, 0.15, h_det.data(), runoff.data());
+
+    rom.rom_quantile_naive = true;
+    rom.computeQuantiles(h_det.data(), invert.data());
+    const std::vector<double> q05_naive = rom.q05;
+    const std::vector<double> q50_naive = rom.q50;
+    const std::vector<double> q95_naive = rom.q95;
+
+    rom.rom_quantile_naive = false;
+    rom.computeQuantiles(h_det.data(), invert.data());
+
+    for (int t = 0; t < rom.n_nodes; ++t) {
+        const auto ut = static_cast<std::size_t>(t);
+        expectRelClose(rom.q05[ut], q05_naive[ut], 1e-12, "q05");
+        expectRelClose(rom.q50[ut], q50_naive[ut], 1e-12, "q50");
+        expectRelClose(rom.q95[ut], q95_naive[ut], 1e-12, "q95");
+        EXPECT_GE(rom.q05[ut], invert[ut] - 1e-12) << "invert clamp must still hold under GEMM";
+    }
+}
+
+TEST(QuantileGemm, SortedMemberValuesStaysFullySortedUnderGemm) {
+    // PR H10's gapModality()/exceedanceFraction() need sortedMemberValues()
+    // fully ascending, not just correct at the three quantile indices --
+    // this is exactly why 1D did NOT switch to nth_element (see
+    // RomQuantileGemm.hpp). Direct regression guard on that property under
+    // the now-default GEMM path.
+    const int N = 20, M = 30, K = 6;
+    GraphEigenBasis basis;
+    CsrGraph L = make_chain_laplacian(N);
+    ASSERT_TRUE(basis.build(L, K));
+
+    SpectralROM1D rom;
+    rom.basis = &basis;
+    rom.n_ensemble = M;
+    rom.mannings_pert = 0.25;
+    rom.runoff_pert   = 0.0;
+    rom.initialize();
+    ASSERT_FALSE(rom.rom_quantile_naive) << "GEMM must be the default path";
+
+    std::vector<double> h0(static_cast<std::size_t>(N));
+    for (int i = 0; i < N; ++i) {
+        double dx = i - N / 3.0;
+        h0[static_cast<std::size_t>(i)] = 0.08 * std::exp(-0.5 * dx * dx / (N / 6.0 * N / 6.0));
+    }
+    rom.seed(h0.data());
+    std::vector<double> h_det = h0;
+    std::vector<double> runoff(static_cast<std::size_t>(N), 0.0);
+    for (int step = 0; step < 30; ++step)
+        rom.advance(20.0, 0.1, h_det.data(), runoff.data());
+    rom.computeQuantiles(h_det.data(), nullptr);
+
+    const auto& mv = rom.sortedMemberValues();
+    ASSERT_EQ(static_cast<int>(mv.size()), rom.n_nodes * M);
+    for (int t = 0; t < rom.n_nodes; ++t) {
+        const double* row = &mv[static_cast<std::size_t>(t) * static_cast<std::size_t>(M)];
+        for (int i = 1; i < M; ++i)
+            EXPECT_LE(row[i - 1], row[i]) << "node " << t << " index " << i
+                                          << ": sortedMemberValues() must stay fully ascending under GEMM";
+    }
+}


### PR DESCRIPTION
<!-- PR body for: hsym2/prh4-quantile-gemm → port/v2-on-marcher
     Compare: https://github.com/HydroCouple/openswmm.engine/compare/port/v2-on-marcher...hsym2/prh4-quantile-gemm -->

# PR H4 — quantile-reconstruction GEMM

Replaces the ROM's hand-written reconstruction loop (the dominant cost of computing the q05/q50/q95 uncertainty bands on large networks) with a single call to Apple's Accelerate BLAS library, since that reconstruction is mathematically just a matrix multiply. Same output, same accuracy — verified against the old code path to 1e-12 — just computed the way a CPU is actually good at doing it. 1D kept its full per-node sort (a different feature, H10's bimodality detector, needs the whole sorted list); 2D switched to a faster partial-selection method since nothing there needs full sorted order.

| Case | N | M | k | naive `computeQuantiles()` | GEMM `computeQuantiles()` | Speedup |
|---|---|---|---|---|---|---|
| 1D (Bellinge, real network) | 1,011 active nodes | 50 | 20 | 4.67–4.70 ms | 0.443–0.454 ms | **10.3–10.6×** |
| 2D (CL-2a reference mesh) | 9,800 triangles | 50 | 20 | 109.4–111.8 ms | 15.5–15.7 ms | **7.0–7.1×** |

