### PR TITLE
Hsym2/prh7 family planes

### DIFF
--- a/docs/uncertainty/HOW_IT_WORKS.md
+++ b/docs/uncertainty/HOW_IT_WORKS.md
@@ -689,10 +689,30 @@ synthetic gages + radar → BME posterior → HDF5 grid file → engine run →
 uncertainty band plot.
 
 **MIXED family**: when a grid file declares `family=MIXED`, each cell carries
-its own distribution family via a `/family_code` uint8 plane. The ROM uses
-the NORMAL coefficient `z_i` for all cells as a v1 approximation; UNIFORM
-cells have their spread pre-scaled by the coefficient range ratio. Exact
-per-cell per-member dispatch is the design's deferred cold path.
+its own distribution family via a `/family_code` uint8 plane. The ROM accepts
+**one spread plane per family** (PR H7): the caller splits the source by
+`/family_code` — family A's cells in one plane with zeros elsewhere, family B's
+in a second plane with zeros elsewhere — and `advance()` projects both, giving
+each plane its own per-member coefficient:
+
+    g_ij  +=  c_i · (Pᵀ·spread_A)_j  +  c_i^B · (Pᵀ·spread_B)_j
+
+so every cell keeps its own family's marginal shape. Both coefficient columns
+are drawn from the same `u_i` stream, so one rank per member still holds across
+families — comonotone coherence is preserved by construction, not by a
+convention that could drift. This replaces the earlier v1 approximation, which
+used the NORMAL coefficient for every cell and pre-scaled UNIFORM cells' spread
+by the coefficient range ratio (≈3.0) to match band *width* while distorting
+the marginal *shape*.
+
+Two caveats. First, per-family planes are a `COHERENCE FULL` feature:
+`COHERENCE CORR_LEN` carries one family per source by construction, so
+CORR_LEN × MIXED is refused with an explanatory error rather than approximated
+(see `VALIDATION.md`, "True per-family coefficient planes"). Second, on this
+branch the *ROM* accepts two planes but the grid `/spread` → ROM wiring that
+would supply them has not been ported to the marcher line yet — only the
+deterministic `/location` plane is read. See VALIDATION.md §5 of that section
+for what a future port should call.
 
 **Deprecation note**: the scalar `RAINFALL` parameter in `[UNCERTAINTY]`
 (which applies a single multiplier to all rainfall) is superseded by soft

--- a/docs/uncertainty/USER_GUIDE.md
+++ b/docs/uncertainty/USER_GUIDE.md
@@ -1690,10 +1690,17 @@ INFLOWS node_grid.h5  CENTROID  FORCE_LOCATION  NODES  nodes.txt
   location parameter and the file supplies spread only.
 - `/spread` is required: `0` at a pixel/time means hard (no uncertainty) there.
 - `/family_code` (MIXED only): per-cell distribution family
-  (0=NORMAL, 1=LOGNORMAL, 2=UNIFORM). The ROM uses the NORMAL coefficient `z_i`
-  for all cells as a v1 approximation; UNIFORM cells have their spread
-  pre-scaled by the coefficient range ratio. Exact per-cell per-member dispatch
-  is the design's deferred cold path.
+  (0=NORMAL, 1=LOGNORMAL, 2=UNIFORM). The ROM carries **one spread plane per
+  family** (PR H7), so each cell keeps its own family's marginal shape rather
+  than borrowing the NORMAL coefficient with a range-matched spread as the
+  earlier v1 approximation did. Both coefficient columns come from the same
+  member-rank stream, so comonotone coherence still holds across families.
+  Restrictions: per-family planes require `COHERENCE FULL` (CORR_LEN × MIXED is
+  refused with an explanatory error — see `VALIDATION.md`, "True per-family
+  coefficient planes"), and two families per file are supported today. Note
+  also that on this branch the grid `/spread` → ROM path itself is not yet
+  wired (only `/location` is read); the per-family capability lives in the ROM
+  ahead of that wiring.
 
 ### 11.4 pybme Round-Trip Example
 

--- a/docs/uncertainty/VALIDATION.md
+++ b/docs/uncertainty/VALIDATION.md
@@ -1003,3 +1003,139 @@ these are the numbers `RomQuantileGemm.hpp`'s first working version produced.
 The benchmark itself is not a checked-in target (compiled standalone per
 this project's calibration-sweep pattern); the numbers in §4 are the full
 record of what was measured.
+
+---
+
+# True per-family coefficient planes (PR H7)
+
+## 1. Problem
+
+Two v1 approximations from the soft-rainfall (SR) arc shared one root cause:
+the ROM carried exactly **one** `(spread, family)` soft-forcing channel, so a
+source whose cells or gages did not all share a distribution family had to be
+squeezed into a single per-member coefficient column.
+
+- **SR-4b (MIXED grids)** used the NORMAL coefficient `z_i` for *every* cell
+  and pre-scaled UNIFORM cells' spread by `max|z| / max|2u−1| ≈ 3.0` so the
+  band width came out comparable. That matches the *range* but distorts the
+  *marginal shape*: a UNIFORM cell's ensemble came out z-shaped (dense near
+  the median, sparse in the tails) rather than evenly spaced.
+- **SR-1b (multi-gage)** did not even range-match: mixed families across gages
+  fell back to the first gage's family with a one-shot warning.
+
+## 2. Fix
+
+`SpectralROM1D::setSoftForcing()` and 2D `SpectralROM::setSoftForcing()` gained
+two trailing, defaulted parameters — a second spread plane and its own family:
+
+    setSoftForcing(loc, spread, family, soft_field,
+                   spread_b /* = nullptr */, family_b /* = UNIFORM */)
+
+`advance()` projects **both** planes (two `k·n` projections instead of one) and
+each member's modal forcing becomes
+
+    g_ij  +=  c_i · (Pᵀ·spread)_j  +  c_i^B · (Pᵀ·spread_b)_j
+
+so each source plane keeps its own family's marginal. The caller splits a MIXED
+source by family: family A's cells/gages carry their spread in `spread` with
+zeros elsewhere, family B's in `spread_b` with zeros elsewhere; the two planes
+are disjoint and sum to the original spread field. The SR-4b `×3.0` pre-scale
+and the SR-1b first-family fallback both become unnecessary — there is no
+longer a single column to squeeze onto.
+
+**Coherence is preserved by construction, not by convention.** Both `c_i` and
+`c_i^B` are drawn from the *same* `u_i = shuffledStrata(M, sample_seed + 4)`
+stream — `c_i = probit(u_i)` for NORMAL/LOGNORMAL, `c_i = 2u_i − 1` for
+UNIFORM. One rank per member therefore holds across families (the
+`COHERENCE FULL` contract), and because the strata midpoints `(k+0.5)/M` are
+symmetric about `0.5`, both columns are zero-mean and the nominal member is
+nominal in *both* channels simultaneously — the deviation-form invariant
+survives the second family without a special case.
+
+**Bit-identity.** A null second plane leaves every expression adding an exact
+`0.0`: the projection loop is skipped, the activation metric gains `|0|·0`, and
+the per-member forcing gains `c^B·0`. Single-family callers are unchanged.
+
+## 3. Scope guard — CORR_LEN × MIXED is refused, not approximated
+
+The correlated-coherence paths (CL-1b/CL-1c materialized field, CL-2c reduced
+basis) fold **one** family's `c_i` into the per-member projection `W_i[t]` /
+`a_im` by construction; there is nowhere for a second family's coefficient to
+enter without redefining that field. Rather than silently mixing families,
+`setSoftForcing()` **refuses** the second plane when a spatial field is active,
+leaves the ROM in a valid single-family CORR_LEN state, and reports why via the
+new `softPlanesError()` accessor (empty on success). `setSoftForcingReduced()`
+is single-family for the same reason and clears any previously armed second
+plane. CORR_LEN × MIXED is additive future work and the error string says so.
+
+## 4. Findings (measured)
+
+**Marginal shapes are exact per plane, and materially different from each
+other.** With the two planes aligned to orthogonal eigenmodes (plane A ∝ mode
+0, plane B ∝ mode 1), each mode is fed by exactly one plane, so the marginal
+claim is exact rather than approximate. Fitting each mode's member values to a
+single amplitude:
+
+| Mode | Fed by | Misfit to its own family | Misfit to the other family |
+|---|---|---|---|
+| 0 | NORMAL plane | < 1e-12 | **0.215** |
+| 1 | UNIFORM plane | < 1e-12 | **0.460** |
+
+Misfit is relative to the fitted amplitude. The cross-family figures are 20–46×
+the 1e-2 assertion bar — the shape difference the pre-H7 hack was papering over
+is large, not marginal.
+
+**What a per-cell test cannot show, and why.** The spec phrased this as
+"UNIFORM cells' member values uniform, not z-shaped". That cannot be asserted
+on a reconstructed per-*cell* value: the ROM's eigenmodes are **global**, so
+every mode sees both planes and every cell's reconstruction is a linear
+combination of both coefficients. That mixing is a property of the spectral ROM
+itself, not something per-family planes can or should remove. The claim that is
+exactly true — and is what H7 actually fixes — is per *source plane*. The tests
+assert it there, and separately verify the full two-plane decomposition against
+an independent closed-form per-member reference on a realistic checkerboard
+MIXED grid.
+
+**Adding a second family plane is NOT monotone in band width — expected, not a
+defect.** On a two-gage fixture where the gages cover complementary halves of
+the network, the per-family band came out *narrower* than the first-family
+fallback's (0.415 vs 1.000 at the widest node with equal spreads; a 58%
+difference with unequal spreads). Cause: comonotone coherence gives every
+member the same rank in both families, and two gages on complementary parts of
+the network project onto the shared zero-mean eigenmodes with **opposing
+signs**, so their contributions partially cancel. With *equal* spreads the two
+projections are exactly `R_B = −R_A` on every mode and the first-family
+fallback — one column over the summed spread — collapses to a near-zero band
+entirely. This is a concrete demonstration of how badly the removed fallback
+could misreport a multi-gage source, and the reason the regression test uses
+unequal spreads (an equal-spread fixture would prove less than it appears).
+
+## 5. Port status — the ROM half is live, the caller half is not on this line
+
+The `port/v2-on-marcher` line deliberately ported the ROM-side soft-forcing API
+but **not** the SR-1a/SR-1b gage consumption or the SR-4b/CL-1c grid `/spread`
+→ ROM path (see `.memory/current.md`, the 2026-08-03 SR-2c entry: only the
+deterministic `/location` plane is read; `SimulationContext::soft_rain` does not
+exist here). The two call sites the checklist asks to *delete* —
+`SurfaceRouter2D::updateRainfall()`'s `sp *= 3.0` and `SWMMEngine`'s
+"uses the first family" warning — therefore live only on the frozen pre-port
+`origin/feature/uncertainty-sidecar` branch and are not present to remove.
+
+**Consequence for whoever ports SR-1b/SR-4b onto this line**: port them against
+the two-plane API, not the v1 hacks. Concretely, `updateRainfall()` should fill
+two spread buffers keyed on `GridFileReader::family_code_now()` and pass both to
+`setSoftForcing()`, instead of writing one buffer with a `×3.0` correction; and
+the gage path should group gages by family into the same two planes instead of
+warning and collapsing onto the first. Grids with more than two distinct
+families in one file still need a third plane — the API extends the same way,
+and nothing about the current shape blocks it.
+
+## 6. Reproduction
+
+    # All 8 H7 tests (6 in 1D, 2 in 2D), plus the 14 pre-existing SR-3a/CL-1b
+    # soft-forcing tests in the same newly-registered binary:
+    ctest --test-dir build/<dir> -R test_engine_soft_forcing_rom
+
+    # Marginal-shape and coherence contracts only:
+    build/<dir>/bin/Debug/test_engine_soft_forcing_rom \
+        --gtest_filter='SoftForcingFamilyPlanes*'

--- a/src/engine/2d/uncertainty/SpectralROM.cpp
+++ b/src/engine/2d/uncertainty/SpectralROM.cpp
@@ -64,10 +64,13 @@ void SpectralROM::clearEnsembleRainfall() {
 
 void SpectralROM::setSoftForcing(const double* loc, const double* spread,
                                 openswmm::uncertainty::DistType family,
-                                const SpatialUncertaintyField* soft_field) noexcept {
+                                const SpatialUncertaintyField* soft_field,
+                                const double* spread_b,
+                                openswmm::uncertainty::DistType family_b) noexcept {
     soft_loc_field_ = loc;
     soft_spread_field_ = spread;
     soft_field_ = soft_field;
+    soft_planes_error_.clear();
     // Switching to the scalar/materialized path must retire any previously
     // configured reduced basis, otherwise advance() would keep taking the
     // reduced path and dereference now-stale pointers. setSoftForcingReduced()
@@ -83,6 +86,42 @@ void SpectralROM::setSoftForcing(const double* loc, const double* spread,
             : soft_z_[ui];
         soft_coeff_[ui] = c;
         soft_max_abs_coeff_ = std::max(soft_max_abs_coeff_, std::abs(c));
+    }
+
+    // ---- PR H7: second per-family coefficient plane -------------------------
+    // Scope guard: the correlated-coherence paths (CL-1c materialized field,
+    // CL-2c reduced basis) carry ONE coefficient family per source by
+    // construction -- W_i[t] / a_im already fold a single family's c_i into
+    // the per-member projection, so there is nowhere for a second family's
+    // coefficient to enter without redefining that field. Refuse the second
+    // plane rather than silently mixing families, and say so.
+    const bool corr_len_active = (soft_field_ != nullptr) && soft_field_->is_spatial();
+    if (spread_b != nullptr && corr_len_active) {
+        soft_planes_error_ =
+            "per-family coefficient planes (MIXED) are not supported together "
+            "with COHERENCE CORR_LEN: the correlated field carries one "
+            "coefficient family per source. Use COHERENCE FULL for MIXED "
+            "grids, or a single family with CORR_LEN. (CORR_LEN x MIXED is "
+            "additive future work -- PR H7 scope guard.)";
+        spread_b = nullptr;
+    }
+    soft_spread_field_b_ = spread_b;
+    soft_max_abs_coeff_b_ = 0.0;
+    if (soft_spread_field_b_ != nullptr) {
+        // Same u_i stream as channel A -- comonotone coherence across families
+        // holds by construction (one rank per member everywhere), and the
+        // nominal member (u_i closest to 0.5) is nominal in BOTH channels.
+        soft_coeff_b_.assign(static_cast<std::size_t>(n_ensemble), 0.0);
+        for (int i = 0; i < n_ensemble; ++i) {
+            const auto ui = static_cast<std::size_t>(i);
+            const double c = (family_b == openswmm::uncertainty::DistType::UNIFORM)
+                ? (2.0 * soft_u_[ui] - 1.0)
+                : soft_z_[ui];
+            soft_coeff_b_[ui] = c;
+            soft_max_abs_coeff_b_ = std::max(soft_max_abs_coeff_b_, std::abs(c));
+        }
+    } else {
+        soft_coeff_b_.clear();
     }
 
     // CL-1c: a supplied spatial field must be dimensionally consistent and its
@@ -115,6 +154,10 @@ void SpectralROM::clearSoftForcing() noexcept {
     soft_reduced_psi_ = nullptr;
     soft_reduced_a_ = nullptr;
     soft_reduced_ks_ = 0;
+    soft_spread_field_b_ = nullptr;
+    soft_coeff_b_.clear();
+    soft_max_abs_coeff_b_ = 0.0;
+    soft_planes_error_.clear();
 }
 
 void SpectralROM::setSoftForcingReduced(const double* loc, const double* spread,
@@ -197,6 +240,7 @@ void SpectralROM::initialize() {
     mode_energy_.assign(static_cast<std::size_t>(n_kept), 0.0);
     h_weight_.assign(static_cast<std::size_t>(n_tri), 1.0);
     soft_r_spread_.assign(static_cast<std::size_t>(n_kept), 0.0);
+    soft_r_spread_b_.assign(static_cast<std::size_t>(n_kept), 0.0);
     soft_spatial_absmax_.assign(static_cast<std::size_t>(n_kept), 0.0);
 
     // All modes start active; mode_active is updated at the start of each advance().
@@ -331,6 +375,22 @@ void SpectralROM::advance(double dt, double K_eff, const double* rainfall,
         }
     } else {
         std::fill(soft_r_spread_.begin(), soft_r_spread_.end(), 0.0);
+    }
+    // PR H7: the second family plane's own projection (P^T spread_b)_j. This is
+    // the "two projections per advance" of the per-family design -- the two
+    // planes are disjoint by construction (each cell contributes to exactly
+    // one, per /family_code), so their sum reconstructs the full spread field
+    // while each cell keeps its own family's coefficient.
+    if (soft_spread_field_b_) {
+        for (std::size_t j = 0; j < nk; ++j) {
+            const double* Pj = &basis->P[j * nt];
+            double dot = 0.0;
+            for (std::size_t t = 0; t < nt; ++t)
+                dot += Pj[t] * soft_spread_field_b_[t];
+            soft_r_spread_b_[j] = dot;
+        }
+    } else {
+        std::fill(soft_r_spread_b_.begin(), soft_r_spread_b_.end(), 0.0);
     }
     // CL-1c: correlated-coherence per-member projection. When a spatial field
     // is active, the comonotone factorization c_i·(Pᵀspread)_j no longer holds;
@@ -528,6 +588,11 @@ void SpectralROM::advance(double dt, double K_eff, const double* rainfall,
                                ? (use_soft_rij ? std::abs(dt)
                                                : std::abs(dt) * soft_max_abs_coeff_)
                                : 0.0;
+    // PR H7: channel B's own activation scale. Zero when no second plane is
+    // configured, so every expression below reduces to the pre-H7 one exactly.
+    const double soft_scale_b = (soft_spread_field_b_ != nullptr)
+                               ? std::abs(dt) * soft_max_abs_coeff_b_
+                               : 0.0;
 
     n_modes_active = 0;
     for (std::size_t j = 0; j < nk; ++j) {
@@ -538,10 +603,17 @@ void SpectralROM::advance(double dt, double K_eff, const double* rainfall,
         bool by_manning = mann_scale > 0.0 &&
                           lam * keff_modes_[j] * std::abs(b_coarse[j]) * mann_scale
                               >= mode_drop_threshold;
-        bool by_soft    = soft_scale > 0.0 &&
-                          (use_soft_rij ? soft_spatial_absmax_[j]
-                                        : std::abs(soft_r_spread_[j])) * soft_scale
-                              >= mode_drop_threshold;
+        // PR H7: sum the two channels' first-order magnitudes rather than
+        // OR-ing two independent tests -- a mode whose per-channel terms are
+        // each just under the threshold but whose combined forcing clears it
+        // must stay active. With no second plane the added term is exactly
+        // 0.0 and the test is the pre-H7 one bit-for-bit.
+        const double soft_metric =
+            (use_soft_rij ? soft_spatial_absmax_[j]
+                          : std::abs(soft_r_spread_[j])) * soft_scale
+            + std::abs(soft_r_spread_b_[j]) * soft_scale_b;
+        bool by_soft    = (soft_scale > 0.0 || soft_scale_b > 0.0) &&
+                          soft_metric >= mode_drop_threshold;
         bool by_vector  = false;
         for (const auto& ep : extra_params_) {
             if (ep.entry == openswmm::uncertainty::ParamEntry::FORCING_VECTOR &&
@@ -610,6 +682,9 @@ void SpectralROM::advance(double dt, double K_eff, const double* rainfall,
                     else
                         g += soft_coeff_[ui] * soft_r_spread_[j];
                 }
+                // PR H7: second family plane, its own coefficient.
+                if (soft_spread_field_b_)
+                    g += soft_coeff_b_[ui] * soft_r_spread_b_[j];
                 if (has_extra) {
                     for (const auto& ep : extra_params_)
                         if (ep.entry == openswmm::uncertainty::ParamEntry::FORCING_VECTOR)
@@ -684,6 +759,12 @@ void SpectralROM::advance(double dt, double K_eff, const double* rainfall,
                 else
                     g += soft_coeff_[ui] * soft_r_spread_[j];
             }
+            // PR H7: second family plane, its own coefficient. Both c_i and
+            // c_i^B come from the same u_i, so member i sits at the same rank
+            // in both families -- comonotone coherence, and a zero-coefficient
+            // (nominal) member contributes exactly zero to both.
+            if (soft_spread_field_b_)
+                g += soft_coeff_b_[ui] * soft_r_spread_b_[j];
             if (has_extra) {
                 for (const auto& ep : extra_params_)
                     if (ep.entry == openswmm::uncertainty::ParamEntry::FORCING_VECTOR)

--- a/src/engine/2d/uncertainty/SpectralROM.hpp
+++ b/src/engine/2d/uncertainty/SpectralROM.hpp
@@ -42,6 +42,7 @@
 #include <vector>
 #include <cstddef>
 #include <cstdint>
+#include <string>
 
 // Forward declaration — avoids pulling 1D uncertainty headers into 2D solver.
 namespace openswmm::uncertainty { struct SpectralROM1D; }
@@ -373,11 +374,39 @@ struct SpectralROM {
      *        equal n_ensemble; its per-cell column mean over members must equal
      *        mean_i(c_i) so q50 still tracks the deterministic answer (checked
      *        by assertion in debug builds).
+     *
+     * @param spread_b Optional SECOND spread plane carrying a DIFFERENT
+     *        distribution family (PR H7). Null (default) leaves the ROM
+     *        single-family and bit-identical to the pre-H7 behaviour. When
+     *        non-null the member forcing sensitivity becomes
+     *
+     *            c_i·(Pᵀ·spread)_j  +  c_i^B·(Pᵀ·spread_b)_j
+     *
+     *        i.e. two projections per advance, one per family. This is what a
+     *        MIXED grid (`/family_code`) needs: cells of family A go in
+     *        @p spread with zeros elsewhere, family B's cells in @p spread_b
+     *        with zeros elsewhere, so every cell keeps its OWN marginal shape
+     *        instead of borrowing one family's coefficient with a range-matched
+     *        spread. NON-OWNING, same lifetime contract as @p spread.
+     * @param family_b Family selecting c_i^B. Both coefficients derive from the
+     *        SAME `u_i = shuffledStrata(M, sample_seed+4)` stream, so one rank
+     *        per member holds across families — the COHERENCE FULL contract —
+     *        and the nominal member is nominal in both channels simultaneously.
+     *
+     * @note Scope guard (PR H7): a second plane is REFUSED when @p soft_field
+     *       is spatial (`COHERENCE CORR_LEN`), because the correlated path
+     *       carries one coefficient family per source by construction. The call
+     *       still succeeds as a single-family call and softPlanesError()
+     *       returns a non-empty explanation; CORR_LEN × MIXED is additive
+     *       future work.
      */
     void setSoftForcing(const double* loc, const double* spread,
                         openswmm::uncertainty::DistType family
                             = openswmm::uncertainty::DistType::NORMAL,
-                        const SpatialUncertaintyField* soft_field = nullptr) noexcept;
+                        const SpatialUncertaintyField* soft_field = nullptr,
+                        const double* spread_b = nullptr,
+                        openswmm::uncertainty::DistType family_b
+                            = openswmm::uncertainty::DistType::UNIFORM) noexcept;
 
     /// Clear the soft forcing path and revert to the legacy forcing inputs.
     void clearSoftForcing() noexcept;
@@ -401,6 +430,11 @@ struct SpectralROM {
      * @p psi_modes (K_s × n_tri row-major) and @p a_coeffs (n_ensemble × K_s
      * row-major) are NON-OWNING and must outlive the ROM (or be cleared). Takes
      * precedence over any `soft_field` set via setSoftForcing.
+     *
+     * @note Single-family only (PR H7 scope guard): this call clears any second
+     *       family plane previously armed via setSoftForcing's `spread_b`, for
+     *       the same reason CORR_LEN × MIXED is refused there — the modal
+     *       coefficients `a_im` fold in one family's `c_i` by construction.
      */
     void setSoftForcingReduced(const double* loc, const double* spread,
                                openswmm::uncertainty::DistType family,
@@ -411,6 +445,16 @@ struct SpectralROM {
     /// setSoftForcing). Empty until setSoftForcing() has been called. Used by
     /// the engine to seed the CL-1c correlated coefficient field.
     const std::vector<double>& softCoeff() const noexcept { return soft_coeff_; }
+
+    /// Per-member coefficient c_i^B of the second family plane (PR H7). Empty
+    /// until a setSoftForcing() call supplied a non-null `spread_b`.
+    const std::vector<double>& softCoeffB() const noexcept { return soft_coeff_b_; }
+
+    /// Empty when the last setSoftForcing() call was honoured in full;
+    /// non-empty when a requested second family plane was REFUSED (currently
+    /// only the CORR_LEN × MIXED combination — see setSoftForcing()). The ROM
+    /// stays in a valid single-family state either way.
+    const std::string& softPlanesError() const noexcept { return soft_planes_error_; }
 
     /**
      * @brief Register an additional uncertain parameter column (PR 9b).
@@ -509,6 +553,18 @@ private:
     std::vector<double> soft_z_;             ///< probit(u_i) — normal/lognormal coefficient.
     std::vector<double> soft_coeff_;         ///< Active per-member coefficient c_i (family-selected).
     double soft_max_abs_coeff_ = 0.0;        ///< max_i |c_i| for mode activation.
+
+    // PR H7 — second per-family coefficient plane. Null unless a caller
+    // supplied a (spread_b, family_b) channel; when null every expression
+    // that reads it adds an exact 0.0, so the single-family path is
+    // bit-identical.
+    const double* soft_spread_field_b_ = nullptr;
+    std::vector<double> soft_r_spread_b_;    ///< (P^T spread_b)_j.
+    std::vector<double> soft_coeff_b_;       ///< Per-member c_i^B (family_b-selected, same u_i).
+    double soft_max_abs_coeff_b_ = 0.0;      ///< max_i |c_i^B| for mode activation.
+    /// Empty on success; set when a second plane was REFUSED (see
+    /// softPlanesError()). Never throws — setSoftForcing is noexcept.
+    std::string soft_planes_error_;
 
     /// CL-1c correlated-coherence (`COHERENCE CORR_LEN`) spatial field. When
     /// non-null and spatial, replaces the scalar `c_i · (P^T spread)_j` term

--- a/src/engine/uncertainty/SpectralROM1D.cpp
+++ b/src/engine/uncertainty/SpectralROM1D.cpp
@@ -51,10 +51,13 @@ void SpectralROM1D::clearEnsembleRunoff() {
 
 void SpectralROM1D::setSoftForcing(const double* loc, const double* spread,
                                   DistType family,
-                                  const SoftSpatialField* soft_field) noexcept {
+                                  const SoftSpatialField* soft_field,
+                                  const double* spread_b,
+                                  DistType family_b) noexcept {
     soft_loc_field_ = loc;
     soft_spread_field_ = spread;
     soft_field_ = soft_field;
+    soft_planes_error_.clear();
     // Switching to the scalar/materialized path must retire any previously
     // configured reduced basis, otherwise advance() would keep taking the
     // reduced path and dereference now-stale pointers. setSoftForcingReduced()
@@ -73,6 +76,42 @@ void SpectralROM1D::setSoftForcing(const double* loc, const double* spread,
             : soft_z_[ui];
         soft_coeff_[ui] = c;
         soft_max_abs_coeff_ = std::max(soft_max_abs_coeff_, std::abs(c));
+    }
+
+    // ---- PR H7: second per-family coefficient plane -------------------------
+    // Scope guard: the correlated-coherence paths (CL-1b materialized field,
+    // CL-2c reduced basis) carry ONE coefficient family per source by
+    // construction -- W_i[t] / a_im already fold a single family's c_i into
+    // the per-member projection, so there is nowhere for a second family's
+    // coefficient to enter without redefining that field. Refuse the second
+    // plane rather than silently mixing families, and say so.
+    const bool corr_len_active = (soft_field_ != nullptr) && soft_field_->is_spatial();
+    if (spread_b != nullptr && corr_len_active) {
+        soft_planes_error_ =
+            "per-family coefficient planes (MIXED) are not supported together "
+            "with COHERENCE CORR_LEN: the correlated field carries one "
+            "coefficient family per source. Use COHERENCE FULL for MIXED "
+            "sources, or a single family with CORR_LEN. (CORR_LEN x MIXED is "
+            "additive future work -- PR H7 scope guard.)";
+        spread_b = nullptr;
+    }
+    soft_spread_field_b_ = spread_b;
+    soft_max_abs_coeff_b_ = 0.0;
+    if (soft_spread_field_b_ != nullptr) {
+        // Same u_i stream as channel A -- comonotone coherence across families
+        // holds by construction (one rank per member everywhere), and the
+        // nominal member (u_i closest to 0.5) is nominal in BOTH channels.
+        soft_coeff_b_.assign(static_cast<std::size_t>(n_ensemble), 0.0);
+        for (int i = 0; i < n_ensemble; ++i) {
+            const auto ui = static_cast<std::size_t>(i);
+            const double c = (family_b == DistType::UNIFORM)
+                ? (2.0 * soft_u_[ui] - 1.0)
+                : soft_z_[ui];
+            soft_coeff_b_[ui] = c;
+            soft_max_abs_coeff_b_ = std::max(soft_max_abs_coeff_b_, std::abs(c));
+        }
+    } else {
+        soft_coeff_b_.clear();
     }
 
     // CL-1b: when a spatial field is supplied it must be dimensionally
@@ -106,6 +145,10 @@ void SpectralROM1D::clearSoftForcing() noexcept {
     soft_reduced_psi_ = nullptr;
     soft_reduced_a_ = nullptr;
     soft_reduced_ks_ = 0;
+    soft_spread_field_b_ = nullptr;
+    soft_coeff_b_.clear();
+    soft_max_abs_coeff_b_ = 0.0;
+    soft_planes_error_.clear();
 }
 
 void SpectralROM1D::setSoftForcingReduced(const double* loc, const double* spread,
@@ -173,6 +216,7 @@ void SpectralROM1D::initialize() {
     mode_energy_.assign(static_cast<std::size_t>(n_kept), 0.0);
     h_det_last_.assign(static_cast<std::size_t>(n_nodes), 0.0);
     soft_r_spread_.assign(static_cast<std::size_t>(n_kept), 0.0);
+    soft_r_spread_b_.assign(static_cast<std::size_t>(n_kept), 0.0);
     soft_spatial_absmax_.assign(static_cast<std::size_t>(n_kept), 0.0);
 
     mode_active.assign(static_cast<std::size_t>(n_kept), true);
@@ -308,6 +352,22 @@ void SpectralROM1D::advance(double dt, double K1d,
         }
     } else {
         std::fill(soft_r_spread_.begin(), soft_r_spread_.end(), 0.0);
+    }
+    // PR H7: the second family plane's own projection (Pᵀ·spread_b)_j. This is
+    // the "two projections per advance" of the per-family design -- the two
+    // planes are disjoint by construction (each cell/gage contributes to
+    // exactly one), so their sum reconstructs the full spread field while each
+    // keeps its own family's coefficient.
+    if (soft_spread_field_b_) {
+        for (std::size_t j = 0; j < nk; ++j) {
+            const double* Pj = &basis->P[j * nn];
+            double dot = 0.0;
+            for (std::size_t i = 0; i < nn; ++i)
+                dot += Pj[i] * soft_spread_field_b_[i];
+            soft_r_spread_b_[j] = dot;
+        }
+    } else {
+        std::fill(soft_r_spread_b_.begin(), soft_r_spread_b_.end(), 0.0);
     }
     // CL-1b: correlated-coherence per-member projection. When a spatial field
     // is active, the comonotone factorization c_i·(Pᵀspread)_j no longer holds;
@@ -453,6 +513,11 @@ void SpectralROM1D::advance(double dt, double K1d,
                                ? (soft_use_rij ? std::abs(dt)
                                                : std::abs(dt) * soft_max_abs_coeff_)
                                : 0.0;
+    // PR H7: channel B's own activation scale. Zero when no second plane is
+    // configured, so every expression below reduces to the pre-H7 one exactly.
+    const double soft_scale_b = (soft_spread_field_b_ != nullptr)
+                               ? std::abs(dt) * soft_max_abs_coeff_b_
+                               : 0.0;
 
     n_modes_active = 0;
     for (std::size_t j = 0; j < nk; ++j) {
@@ -462,10 +527,17 @@ void SpectralROM1D::advance(double dt, double K1d,
                           std::abs(r_coarse[j]) * rain_scale >= mode_drop_threshold;
         bool by_manning = mann_scale > 0.0 &&
                           lam * std::abs(b_coarse[j]) * mann_scale >= mode_drop_threshold;
-        bool by_soft    = soft_scale > 0.0 &&
-                  (soft_use_rij ? soft_spatial_absmax_[j]
-                                : std::abs(soft_r_spread_[j])) * soft_scale
-                      >= mode_drop_threshold;
+        // PR H7: sum the two channels' first-order magnitudes rather than
+        // OR-ing two independent tests -- a mode whose per-channel terms are
+        // each just under the threshold but whose combined forcing clears it
+        // must stay active. With no second plane the added term is exactly
+        // 0.0 and the test is the pre-H7 one bit-for-bit.
+        const double soft_metric =
+            (soft_use_rij ? soft_spatial_absmax_[j]
+                          : std::abs(soft_r_spread_[j])) * soft_scale
+            + std::abs(soft_r_spread_b_[j]) * soft_scale_b;
+        bool by_soft    = (soft_scale > 0.0 || soft_scale_b > 0.0) &&
+                          soft_metric >= mode_drop_threshold;
         bool by_vector  = false;
         for (const auto& ep : extra_params_) {
             if (ep.entry == ParamEntry::FORCING_VECTOR &&
@@ -508,6 +580,12 @@ void SpectralROM1D::advance(double dt, double K1d,
                 else
                     g += soft_coeff_[ui] * soft_r_spread_[j];
             }
+            // PR H7: second family plane, its own coefficient. Both c_i and
+            // c_i^B come from the same u_i, so member i sits at the same rank
+            // in both families -- comonotone coherence, and a zero-coefficient
+            // (nominal) member contributes exactly zero to both.
+            if (soft_spread_field_b_)
+                g += soft_coeff_b_[ui] * soft_r_spread_b_[j];
             if (has_extra) {
                 for (const auto& ep : extra_params_)
                     if (ep.entry == ParamEntry::FORCING_VECTOR)

--- a/src/engine/uncertainty/SpectralROM1D.hpp
+++ b/src/engine/uncertainty/SpectralROM1D.hpp
@@ -44,6 +44,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <string>
 
 namespace openswmm::uncertainty {
 
@@ -232,10 +233,37 @@ struct SpectralROM1D {
      *        `n_members` must equal n_ensemble; its per-node column mean over
      *        members must equal mean_i(c_i) so q50 still tracks the
      *        deterministic answer (checked by assertion in debug builds).
+     *
+     * @param spread_b Optional SECOND spread plane carrying a DIFFERENT
+     *        distribution family (PR H7). Null (default) leaves the ROM
+     *        single-family and bit-identical to the pre-H7 behaviour. When
+     *        non-null the member forcing sensitivity becomes
+     *
+     *            c_i·(Pᵀ·spread)_j  +  c_i^B·(Pᵀ·spread_b)_j
+     *
+     *        i.e. two projections per advance, one per family, instead of one
+     *        family's coefficient applied to a range-matched single plane.
+     *        NON-OWNING, same lifetime contract as @p spread. Callers split a
+     *        MIXED source by family: cells/gages of family A go in @p spread
+     *        (zero elsewhere), family B's go in @p spread_b (zero elsewhere).
+     * @param family_b Family selecting c_i^B. Both coefficients derive from
+     *        the SAME `u_i = shuffledStrata(M, sample_seed+4)` stream, so one
+     *        rank per member holds across families — the COHERENCE FULL
+     *        contract — and the nominal member is nominal in both channels
+     *        simultaneously.
+     *
+     * @note Scope guard (PR H7): a second plane is REFUSED when @p soft_field
+     *       is spatial (`COHERENCE CORR_LEN`), because the correlated path
+     *       carries one coefficient family per source by construction. The
+     *       call still succeeds as a single-family call and softPlanesError()
+     *       returns a non-empty explanation; CORR_LEN × MIXED is additive
+     *       future work.
      */
     void setSoftForcing(const double* loc, const double* spread,
                         DistType family = DistType::NORMAL,
-                        const SoftSpatialField* soft_field = nullptr) noexcept;
+                        const SoftSpatialField* soft_field = nullptr,
+                        const double* spread_b = nullptr,
+                        DistType family_b = DistType::UNIFORM) noexcept;
 
     /// Clear the soft forcing path and revert to the legacy forcing inputs.
     void clearSoftForcing() noexcept;
@@ -263,6 +291,11 @@ struct SpectralROM1D {
      * `n_ensemble × K_s` row-major. Takes precedence over any `soft_field` set
      * via setSoftForcing.
      *
+     * @note Single-family only (PR H7 scope guard): this call clears any second
+     *       family plane previously armed via setSoftForcing's `spread_b`, for
+     *       the same reason CORR_LEN × MIXED is refused there — the modal
+     *       coefficients `a_im` fold in one family's `c_i` by construction.
+     *
      * @param loc        Location field (may be null); same role as setSoftForcing.
      * @param spread     Spread field (non-null to activate); NON-OWNING.
      * @param family     Distribution family (selects the comonotone c_i).
@@ -279,6 +312,16 @@ struct SpectralROM1D {
     /// setSoftForcing). Empty until setSoftForcing() has been called. Used by
     /// the engine to seed the CL-1c correlated coefficient field.
     const std::vector<double>& softCoeff() const noexcept { return soft_coeff_; }
+
+    /// Per-member coefficient c_i^B of the second family plane (PR H7). Empty
+    /// until a setSoftForcing() call supplied a non-null `spread_b`.
+    const std::vector<double>& softCoeffB() const noexcept { return soft_coeff_b_; }
+
+    /// Empty when the last setSoftForcing() call was honoured in full;
+    /// non-empty when a requested second family plane was REFUSED (currently
+    /// only the CORR_LEN × MIXED combination — see setSoftForcing()). The ROM
+    /// stays in a valid single-family state either way.
+    const std::string& softPlanesError() const noexcept { return soft_planes_error_; }
 
     /**
      * @brief Register an additional uncertain parameter column (PR 9b).
@@ -524,6 +567,17 @@ private:
     std::vector<double> soft_z_;             ///< probit(u_i) — normal/lognormal coefficient.
     std::vector<double> soft_coeff_;         ///< Active per-member coefficient c_i (family-selected).
     double soft_max_abs_coeff_ = 0.0;        ///< max_i |c_i| for mode activation.
+
+    // PR H7 — second per-family coefficient plane. Null unless a caller
+    // supplied a (spread_b, family_b) channel; when null every expression
+    // below adds an exact 0.0, so the single-family path is bit-identical.
+    const double* soft_spread_field_b_ = nullptr;
+    std::vector<double> soft_r_spread_b_;    ///< (P^T spread_b)_j.
+    std::vector<double> soft_coeff_b_;       ///< Per-member c_i^B (family_b-selected, same u_i).
+    double soft_max_abs_coeff_b_ = 0.0;      ///< max_i |c_i^B| for mode activation.
+    /// Empty on success; set when a second plane was REFUSED (see
+    /// softPlanesError()). Never throws — setSoftForcing is noexcept.
+    std::string soft_planes_error_;
 
     /// CL-1b correlated-coherence (`COHERENCE CORR_LEN`) spatial field. When
     /// non-null and spatial, replaces the scalar `c_i · (P^T spread)_j` term

--- a/tests/regression/CMakeLists.txt
+++ b/tests/regression/CMakeLists.txt
@@ -173,4 +173,39 @@ if(OPENSWMM_BUILD_2D)
     add_test(NAME regression_rom_coverage_bellinge COMMAND $<TARGET_FILE:test_rom_coverage_bellinge>)
     set_tests_properties(regression_rom_coverage_bellinge PROPERTIES LABELS "regression")
     openswmm_stage_test_runtime_deps(test_rom_coverage_bellinge)
+    # ---- CL-2a: correlation-length profile of the reduced spatial basis ----
+    # Found dormant in the 2026-08-18 sweep: on disk since the mechanical port,
+    # never registered. Drives the ROM's setSoftForcing() directly (no
+    # [SOFT_RAINGAGES] parser dependency), so unlike its two SR-5 siblings it
+    # runs on this base as-is.
+    add_executable(test_corr_len_profile test_corr_len_profile.cpp
+        ${PROJECT_SOURCE_DIR}/src/engine/uncertainty/SpdeSpatialBasis.cpp)
+    target_link_libraries(test_corr_len_profile
+        PRIVATE
+            GTest::gtest GTest::gtest_main
+            openswmm_engine
+    )
+    target_include_directories(test_corr_len_profile
+        PRIVATE
+            ${PROJECT_SOURCE_DIR}/include
+            ${PROJECT_SOURCE_DIR}/src/engine
+    )
+    set_target_properties(test_corr_len_profile PROPERTIES
+        CXX_STANDARD 20
+        CXX_STANDARD_REQUIRED ON
+    )
+    add_test(NAME regression_corr_len_profile COMMAND $<TARGET_FILE:test_corr_len_profile>)
+    set_tests_properties(regression_corr_len_profile PROPERTIES
+        LABELS "regression"
+        ENVIRONMENT "OPENSWMM_2D_BACKEND=cpu")
+    openswmm_stage_test_runtime_deps(test_corr_len_profile)
+
+    # ---- Deliberately NOT registered (2026-08-18 sweep) --------------------
+    # test_soft_rain_coverage.cpp and test_soft_rain_corr_coverage.cpp (SR-5)
+    # both write a [SOFT_RAINGAGES] section into a .inp and drive the engine
+    # end to end. That parser was deliberately not ported to this base (see
+    # src/engine/uncertainty/QualityUncertaintyHandler.cpp), so the section is
+    # silently ignored, no gage spread reaches the ROM, and every assertion
+    # fails for that one reason. They are ready-made acceptance gates for
+    # whoever ports SR-1a/SR-1b -- register them then, not before.
 endif()

--- a/tests/unit/engine/CMakeLists.txt
+++ b/tests/unit/engine/CMakeLists.txt
@@ -762,3 +762,73 @@ if(OPENSWMM_WITH_GEOPACKAGE)
     set_tests_properties(test_engine_geopackage_external_content_reader
         PROPERTIES LABELS "unit")
 endif()
+
+# ===========================================================================
+# DORMANT-TEST SWEEP (2026-08-18)
+#
+# Every test source under tests/unit/engine/ that was present on disk but
+# referenced by no CMakeLists -- i.e. had never run under ctest on this line.
+# Four such files had already been found one at a time (PR-10's coverage
+# harness before P4, test_spectral_rom1d.cpp before H1, test_2d_spectral_rom.cpp
+# before H4, test_soft_forcing_rom.cpp before H7), each passing immediately once
+# switched on. This block is the deliberate sweep for the rest of them rather
+# than waiting to trip over the next one.
+#
+# Files that genuinely cannot build on this base (they reference APIs the R0
+# port deliberately left behind) are listed at the bottom of this block, NOT
+# registered, with the reason -- so the gap stays visible instead of silently
+# reverting to "present on disk, never run".
+# ===========================================================================
+
+add_gtest_unit(test_engine_2d_spatial_field       test_2d_spatial_field.cpp)
+add_gtest_unit(test_engine_1d_rom_integration     test_engine_1d_rom_integration.cpp)
+add_gtest_unit(test_engine_final_boundary_stall2  test_engine_final_boundary_stall.cpp)
+add_gtest_unit(test_engine_final_boundary_stall   test_final_boundary_stall.cpp)
+add_gtest_unit(test_engine_grid_mapping_weights   test_grid_mapping_weights.cpp)
+# RunoffEnsemble.cpp and SpdeSpatialBasis.cpp are NOT in the engine library --
+# src/engine/CMakeLists.txt lists uncertainty/*.cpp explicitly "as each lands",
+# and these two have no ported consumer yet. Compile them straight into their
+# own test target (the same pattern test_engine_spectral_rom1d used before its
+# source was wired) so the code is exercised without pre-empting the port
+# decision about whether to link them into the engine.
+add_gtest_unit(test_engine_runoff_ensemble        test_runoff_ensemble.cpp)
+target_sources(test_engine_runoff_ensemble PRIVATE
+    ${PROJECT_SOURCE_DIR}/src/engine/uncertainty/RunoffEnsemble.cpp)
+add_gtest_unit(test_engine_site_drainage_model    test_site_drainage_model.cpp)
+add_gtest_unit(test_engine_soft_rain_grid_parser  test_soft_rain_grid_parser.cpp)
+add_gtest_unit(test_engine_spde_spatial_basis     test_spde_spatial_basis.cpp)
+target_sources(test_engine_spde_spatial_basis PRIVATE
+    ${PROJECT_SOURCE_DIR}/src/engine/uncertainty/SpdeSpatialBasis.cpp)
+if(OPENSWMM_BUILD_2D)
+    add_gtest_unit(test_engine_2d_rom_integration test_engine_2d_rom_integration.cpp)
+endif()
+
+# ---- Deliberately NOT registered: these do not build on this base ----------
+# Each was compile-checked during the 2026-08-18 sweep; the blocker is a
+# genuinely un-ported feature, not a broken test.
+#
+#   test_engine_wq_uncertainty.cpp  -- needs SWMMEngine::wq_unc_active /
+#       wq_conc_prev_ (post-reform PR 13b, the WQ QUALITY uncertainty layer).
+#       Never ported to this line.
+#
+#   test_soft_rain_parser.cpp       -- needs SimulationContext::soft_rain and
+#       parseSoftRaingagesLine (SR-1a/SR-1b gage-level soft rainfall). The R0
+#       port deliberately excluded both; see the note at the removal site in
+#       src/engine/uncertainty/QualityUncertaintyHandler.cpp.
+#
+#   test_soft_rain_gage_engine.cpp  -- COMPILES and RUNS on this base, but all
+#       6 tests fail for one reason: they write a [SOFT_RAINGAGES] section into
+#       a .inp and drive the engine end to end, and that section has no
+#       registered parser here, so it is silently ignored and no gage spread
+#       ever reaches the ROM. Left unregistered on purpose: this is a
+#       feature-ABSENT red, not a defect red, and a permanently red target
+#       would erode what a red gate means on this line (contrast
+#       regression_rom_coverage, which is deliberately red over a real
+#       NUMERICAL question and must stay registered). It is a ready-made
+#       acceptance gate for the SR-1a/SR-1b port -- turn it on then.
+#
+#   test_spectral_correction.cpp    -- needs hydraulics/SpectralCoarse.cpp,
+#       which src/engine/CMakeLists.txt EXCLUDES on purpose (the DW
+#       spectral_accel scaffolding is unported and the feature itself was
+#       closed as unsafe for large networks -- see .memory/current.md).
+#       Registering this would mean un-excluding closed code; leave it off.

--- a/tests/unit/engine/CMakeLists.txt
+++ b/tests/unit/engine/CMakeLists.txt
@@ -256,6 +256,13 @@ if(OPENSWMM_BUILD_2D)
     # quantile-reconstruction equivalence tests -- found dormant, registered.
     add_gtest_unit(test_engine_2d_spectral_rom test_2d_spectral_rom.cpp)
 
+    # Soft-forcing (SR-3a) API on BOTH ROMs -- 1D and 2D in one binary, which
+    # is why it lives in the 2D-gated block rather than next to
+    # test_engine_spectral_rom1d. Same dormant-file story as the line above:
+    # on disk since the mechanical port, never registered until PR H7 needed
+    # a home for its per-family-coefficient-plane tests.
+    add_gtest_unit(test_engine_soft_forcing_rom test_soft_forcing_rom.cpp)
+
     # SurfaceRouter2D's wiring of the calibrated reduced operator: production
     # default vs rom_legacy_operator fallback, and open-boundary grounding
     # reachable through the router's own boundary_ (not just at the

--- a/tests/unit/engine/CMakeLists.txt
+++ b/tests/unit/engine/CMakeLists.txt
@@ -780,10 +780,25 @@ endif()
 # reverting to "present on disk, never run".
 # ===========================================================================
 
-add_gtest_unit(test_engine_2d_spatial_field       test_2d_spatial_field.cpp)
-add_gtest_unit(test_engine_1d_rom_integration     test_engine_1d_rom_integration.cpp)
-add_gtest_unit(test_engine_final_boundary_stall2  test_engine_final_boundary_stall.cpp)
-add_gtest_unit(test_engine_final_boundary_stall   test_final_boundary_stall.cpp)
+if(OPENSWMM_BUILD_2D)
+    # Depends on 2d/uncertainty/CorrelatedFieldGenerator.cpp, which
+    # src/engine/CMakeLists.txt only compiles into OPENSWMM_2D_SOURCES --
+    # undefined-reference at link time with -DOPENSWMM_BUILD_2D=OFF otherwise.
+    add_gtest_unit(test_engine_2d_spatial_field   test_2d_spatial_field.cpp)
+endif()
+if(OPENSWMM_BUILD_2D)
+    # SWMMEngine::rom1d() is itself declared inside #ifdef OPENSWMM_HAS_2D in
+    # SWMMEngine.hpp (a pre-existing quirk -- the 1D ROM member is unconditional,
+    # only its accessor is gated), so this test cannot build without 2D.
+    add_gtest_unit(test_engine_1d_rom_integration test_engine_1d_rom_integration.cpp)
+endif()
+# Two independently-written PR 11 regression tests for the same fix, same
+# subject, different fixtures -- kept as two targets rather than merged.
+# Named after each file's own stem (not the usual test_engine_<x> <- test_<x>.cpp
+# convention) because that convention collides here: stripping "test_" from
+# both stems and re-prefixing would make both targets "test_engine_final_boundary_stall".
+add_gtest_unit(test_engine_final_boundary_stall   test_engine_final_boundary_stall.cpp)
+add_gtest_unit(test_final_boundary_stall          test_final_boundary_stall.cpp)
 add_gtest_unit(test_engine_grid_mapping_weights   test_grid_mapping_weights.cpp)
 # RunoffEnsemble.cpp and SpdeSpatialBasis.cpp are NOT in the engine library --
 # src/engine/CMakeLists.txt lists uncertainty/*.cpp explicitly "as each lands",
@@ -795,7 +810,12 @@ add_gtest_unit(test_engine_runoff_ensemble        test_runoff_ensemble.cpp)
 target_sources(test_engine_runoff_ensemble PRIVATE
     ${PROJECT_SOURCE_DIR}/src/engine/uncertainty/RunoffEnsemble.cpp)
 add_gtest_unit(test_engine_site_drainage_model    test_site_drainage_model.cpp)
-add_gtest_unit(test_engine_soft_rain_grid_parser  test_soft_rain_grid_parser.cpp)
+if(OPENSWMM_BUILD_2D)
+    # parseSoftRainfallGridLine is defined in uncertainty/QualityUncertaintyHandler.cpp,
+    # which src/engine/CMakeLists.txt only compiles into OPENSWMM_2D_SOURCES --
+    # undefined-reference at link time with -DOPENSWMM_BUILD_2D=OFF otherwise.
+    add_gtest_unit(test_engine_soft_rain_grid_parser test_soft_rain_grid_parser.cpp)
+endif()
 add_gtest_unit(test_engine_spde_spatial_basis     test_spde_spatial_basis.cpp)
 target_sources(test_engine_spde_spatial_basis PRIVATE
     ${PROJECT_SOURCE_DIR}/src/engine/uncertainty/SpdeSpatialBasis.cpp)

--- a/tests/unit/engine/test_soft_forcing_rom.cpp
+++ b/tests/unit/engine/test_soft_forcing_rom.cpp
@@ -572,3 +572,610 @@ TEST(SoftForcingCorrelated2D, ComonotoneFieldMatchesScalarPath) {
 
 } // anonymous namespace
 
+
+// ===========================================================================
+// PR H7 — true per-family coefficient planes (MIXED + multi-gage)
+//
+// Before H7 the ROM carried ONE (spread, family) channel, so a MIXED source
+// had to borrow a single family's coefficient column for every cell/gage and
+// range-match the others by pre-scaling their spread (the SR-4b ~3.0x hack) or
+// fall back to the first family outright (SR-1b). H7 adds a second, nullable
+// (spread_b, family_b) channel: two projections per advance, each carrying its
+// OWN family's per-member coefficient,
+//
+//     g_ij  +=  c_i * (P^T spread)_j  +  c_i^B * (P^T spread_b)_j
+//
+// with both coefficient columns drawn from the SAME u_i stream
+// (shuffledStrata(M, sample_seed+4)) so comonotone coherence -- one rank per
+// member everywhere, the COHERENCE FULL contract -- is preserved across
+// families by construction.
+//
+// NOTE ON WHAT IS AND IS NOT TESTABLE PER CELL. The spec's phrasing ("UNIFORM
+// cells' member values uniform ... not z-shaped") cannot be asserted on a
+// reconstructed per-CELL value: the ROM's eigenmodes are GLOBAL, so every mode
+// sees both planes and every cell's reconstruction is a linear combination of
+// both coefficients. That mixing is a property of the spectral ROM itself, not
+// something per-family planes can or should remove. The claim that IS exactly
+// true -- and is what H7 actually fixes -- is per SOURCE PLANE: each plane's
+// modal forcing carries its own family's coefficient column. The marginal-shape
+// tests below therefore use spread planes aligned with ORTHOGONAL eigenmodes,
+// which isolates one plane per mode and makes the marginal claim exact rather
+// than approximate, and the checkerboard fixture then verifies the full
+// two-plane decomposition end to end against an independent analytic
+// per-member reference.
+// ===========================================================================
+
+// Analytic single-step modal solution from a zero initial deviation:
+//   d(da)/dt = -rate*da + g,  da(0) = 0  =>  da(dt) = (g/rate)*(1-exp(-rate*dt))
+// (Euler below the rate floor). Used as an independent reference so the tests
+// do not merely re-derive the ROM's own arithmetic.
+static double analyticStepFromZero(double g, double rate, double dt) {
+    if (rate > 1.0e-12)
+        return (g / rate) * (1.0 - std::exp(-rate * dt));
+    return g * dt;
+}
+
+// Spearman-style check: two coefficient columns are comonotone when sorting
+// members by one also sorts them by the other (identical rank permutation).
+static bool sameRankOrder(const std::vector<double>& a,
+                          const std::vector<double>& b) {
+    const std::size_t M = a.size();
+    if (b.size() != M) return false;
+    std::vector<std::size_t> ia(M), ib(M);
+    for (std::size_t i = 0; i < M; ++i) { ia[i] = i; ib[i] = i; }
+    std::sort(ia.begin(), ia.end(), [&](std::size_t p, std::size_t q) { return a[p] < a[q]; });
+    std::sort(ib.begin(), ib.end(), [&](std::size_t p, std::size_t q) { return b[p] < b[q]; });
+    return ia == ib;
+}
+
+// ---------------------------------------------------------------------------
+// Coefficient-column contract
+// ---------------------------------------------------------------------------
+
+TEST(SoftForcingFamilyPlanes, BothChannelsShareOneRankPerMember) {
+    CsrGraph L = make_chain_laplacian(8);
+    GraphEigenBasis basis;
+    ASSERT_TRUE(basis.build(L, 4));
+
+    SpectralROM1D rom;
+    rom.basis = &basis;
+    rom.n_ensemble = 21;            // odd -> one member sits exactly at u = 0.5
+    rom.mannings_pert = 0.0;
+    rom.runoff_pert = 0.0;
+    rom.initialize();
+
+    const auto nn = static_cast<std::size_t>(basis.n_nodes);
+    std::vector<double> h_det(nn, 0.0), spread_a(nn), spread_b(nn);
+    const double* mode0 = &basis.P[0];
+    const double* mode1 = &basis.P[nn];
+    for (std::size_t t = 0; t < nn; ++t) {
+        spread_a[t] = 0.5 * mode0[t];
+        spread_b[t] = 0.5 * mode1[t];
+    }
+
+    rom.seed(h_det.data());
+    rom.setSoftForcing(nullptr, spread_a.data(), DistType::NORMAL, nullptr,
+                       spread_b.data(), DistType::UNIFORM);
+
+    ASSERT_TRUE(rom.softPlanesError().empty()) << rom.softPlanesError();
+    ASSERT_EQ(static_cast<int>(rom.softCoeffB().size()), rom.n_ensemble);
+
+    // COHERENCE FULL contract: one rank per member across families.
+    EXPECT_TRUE(sameRankOrder(rom.softCoeff(), rom.softCoeffB()));
+
+    // Both columns are zero-mean, so neither channel shifts the median.
+    double mean_a = 0.0, mean_b = 0.0;
+    for (int i = 0; i < rom.n_ensemble; ++i) {
+        mean_a += rom.softCoeff()[static_cast<std::size_t>(i)];
+        mean_b += rom.softCoeffB()[static_cast<std::size_t>(i)];
+    }
+    EXPECT_NEAR(mean_a / rom.n_ensemble, 0.0, 1.0e-12);
+    EXPECT_NEAR(mean_b / rom.n_ensemble, 0.0, 1.0e-12);
+
+    // The nominal member is nominal in BOTH channels simultaneously -- the
+    // property that makes the deviation-form invariant survive two families.
+    int nominal = -1;
+    for (int i = 0; i < rom.n_ensemble; ++i)
+        if (std::abs(rom.softCoeffB()[static_cast<std::size_t>(i)]) < 1.0e-15)
+            nominal = i;
+    ASSERT_GE(nominal, 0) << "odd M must place one member exactly at u = 0.5";
+    EXPECT_NEAR(rom.softCoeff()[static_cast<std::size_t>(nominal)], 0.0, 1.0e-12);
+
+    rom.advance(1.0, 0.5, h_det.data(), nullptr, h_det.data());
+    const auto nk = static_cast<std::size_t>(rom.n_kept);
+    for (std::size_t j = 0; j < nk; ++j)
+        EXPECT_NEAR(rom.a_ensemble[static_cast<std::size_t>(nominal) * nk + j],
+                    0.0, 1.0e-15) << "nominal member mode " << j;
+}
+
+// ---------------------------------------------------------------------------
+// The marginal-shape claim, made exact by aligning each plane with its own
+// eigenmode: mode 0 is fed only by the NORMAL plane, mode 1 only by the
+// UNIFORM plane, so each mode's member values must follow that family's
+// quantiles -- and, decisively, NOT the other's. Under the pre-H7 hack both
+// modes would have carried the NORMAL column.
+// ---------------------------------------------------------------------------
+
+TEST(SoftForcingFamilyPlanes, EachPlaneKeepsItsOwnMarginalShape) {
+    CsrGraph L = make_chain_laplacian(10);
+    GraphEigenBasis basis;
+    ASSERT_TRUE(basis.build(L, 4));
+
+    SpectralROM1D rom;
+    rom.basis = &basis;
+    rom.n_ensemble = 25;
+    rom.mannings_pert = 0.0;
+    rom.runoff_pert = 0.0;
+    rom.mode_drop_threshold = 0.0;   // keep every mode active; isolate the test
+    rom.initialize();
+
+    const auto nn = static_cast<std::size_t>(basis.n_nodes);
+    std::vector<double> h_det(nn, 0.0), spread_a(nn), spread_b(nn);
+    const double* mode0 = &basis.P[0];
+    const double* mode1 = &basis.P[nn];
+    for (std::size_t t = 0; t < nn; ++t) {
+        spread_a[t] = 0.7 * mode0[t];   // -> R_A = (0.7, 0, 0, ...)
+        spread_b[t] = 0.7 * mode1[t];   // -> R_B = (0, 0.7, 0, ...)
+    }
+
+    rom.seed(h_det.data());
+    rom.setSoftForcing(nullptr, spread_a.data(), DistType::NORMAL, nullptr,
+                       spread_b.data(), DistType::UNIFORM);
+    ASSERT_TRUE(rom.softPlanesError().empty());
+    rom.advance(1.0, 0.5, h_det.data(), nullptr, h_det.data());
+
+    const auto nk = static_cast<std::size_t>(rom.n_kept);
+    const int   M = rom.n_ensemble;
+    ASSERT_GE(rom.n_kept, 2);
+
+    // Orthonormal basis => the two planes land on disjoint modes.
+    EXPECT_NEAR(rom.soft_r_spread_[0],   0.7, 1.0e-12);
+    EXPECT_NEAR(rom.soft_r_spread_[1],   0.0, 1.0e-12);
+    EXPECT_NEAR(rom.soft_r_spread_b_[0], 0.0, 1.0e-12);
+    EXPECT_NEAR(rom.soft_r_spread_b_[1], 0.7, 1.0e-12);
+
+    // Mode 0 must be proportional to z_i (NORMAL) and mode 1 to (2u_i - 1)
+    // (UNIFORM). Fit each mode's scale off a single member, then require every
+    // other member to match that family's quantile to machine precision.
+    auto shapeMisfit = [&](std::size_t mode, const std::vector<double>& coeff) {
+        std::size_t ref = 0;
+        for (int i = 0; i < M; ++i)
+            if (std::abs(coeff[static_cast<std::size_t>(i)]) >
+                std::abs(coeff[ref])) ref = static_cast<std::size_t>(i);
+        const double scale = rom.a_ensemble[ref * nk + mode] / coeff[ref];
+        double worst = 0.0;
+        for (int i = 0; i < M; ++i) {
+            const auto ui = static_cast<std::size_t>(i);
+            const double predicted = scale * coeff[ui];
+            worst = std::max(worst,
+                std::abs(rom.a_ensemble[ui * nk + mode] - predicted));
+        }
+        return worst / std::abs(scale);   // relative to the fitted amplitude
+    };
+
+    // Each mode fits its OWN family essentially exactly ...
+    EXPECT_LT(shapeMisfit(0, rom.softCoeff()),  1.0e-12);
+    EXPECT_LT(shapeMisfit(1, rom.softCoeffB()), 1.0e-12);
+    // ... and is a poor fit to the other family, which is precisely the defect
+    // the pre-H7 single-column hack had: a UNIFORM source rendered z-shaped.
+    // Measured cross-family misfit on this fixture: 0.460 (mode 1 against the
+    // NORMAL column) and 0.215 (mode 0 against the UNIFORM column), i.e. 20-46x
+    // the 1e-2 bar below -- a wide margin, not a tuned threshold.
+    EXPECT_GT(shapeMisfit(1, rom.softCoeff()),  1.0e-2);
+    EXPECT_GT(shapeMisfit(0, rom.softCoeffB()), 1.0e-2);
+}
+
+// ---------------------------------------------------------------------------
+// Regression lock: a caller that supplies no second plane -- or supplies one
+// that is identically zero -- must be bit-identical to the single-family path.
+// This is the "single-family paths bit-identical before/after" gate; the 14
+// pre-existing SR-3a/CL-1b tests in this file are its companion (they exercise
+// the single-family path exclusively and are unchanged by H7).
+// ---------------------------------------------------------------------------
+
+TEST(SoftForcingFamilyPlanes, NullAndZeroSecondPlaneAreBitIdentical) {
+    CsrGraph L = make_chain_laplacian(8);
+    GraphEigenBasis basis;
+    ASSERT_TRUE(basis.build(L, 4));
+
+    const auto nn = static_cast<std::size_t>(basis.n_nodes);
+    std::vector<double> h_det(nn, 0.0), loc(nn), spread(nn);
+    std::vector<double> zero_plane(nn, 0.0);
+    const double* mode0 = &basis.P[0];
+    const double* mode1 = &basis.P[nn];
+    for (std::size_t t = 0; t < nn; ++t) {
+        loc[t]    = mode0[t];
+        spread[t] = 0.4 * mode0[t] + 0.25 * mode1[t];
+    }
+
+    auto run = [&](const double* second) {
+        SpectralROM1D rom;
+        rom.basis = &basis;
+        rom.n_ensemble = 11;
+        rom.mannings_pert = 0.0;
+        rom.runoff_pert = 0.0;
+        rom.initialize();
+        rom.seed(h_det.data());
+        rom.setSoftForcing(loc.data(), spread.data(), DistType::NORMAL,
+                           nullptr, second, DistType::UNIFORM);
+        rom.advance(1.0, 0.5, h_det.data(), nullptr, h_det.data());
+        rom.computeQuantiles(h_det.data(), nullptr);
+        return rom;
+    };
+
+    SpectralROM1D none = run(nullptr);
+    SpectralROM1D zero = run(zero_plane.data());
+
+    ASSERT_EQ(none.n_modes_active, zero.n_modes_active);
+    for (std::size_t i = 0; i < none.a_ensemble.size(); ++i)
+        EXPECT_EQ(none.a_ensemble[i], zero.a_ensemble[i])   // EQ, not NEAR
+            << "member/mode flat index " << i;
+    for (std::size_t t = 0; t < nn; ++t) {
+        EXPECT_EQ(none.q05[t], zero.q05[t]);
+        EXPECT_EQ(none.q50[t], zero.q50[t]);
+        EXPECT_EQ(none.q95[t], zero.q95[t]);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Superposition: the two-plane result equals the sum of the two single-plane
+// results (each run with ITS OWN family), because the modal ODE is linear in
+// the forcing and every run starts from an identical zero deviation. This is
+// the structural statement that "two projections, one coefficient each" is
+// what actually got implemented -- not a range-matched single column.
+// ---------------------------------------------------------------------------
+
+TEST(SoftForcingFamilyPlanes, TwoPlanesSuperposeTheirSingleFamilyRuns) {
+    CsrGraph L = make_chain_laplacian(9);
+    GraphEigenBasis basis;
+    ASSERT_TRUE(basis.build(L, 4));
+
+    const auto nn = static_cast<std::size_t>(basis.n_nodes);
+    std::vector<double> h_det(nn, 0.0), spread_a(nn), spread_b(nn);
+    const double* mode0 = &basis.P[0];
+    const double* mode1 = &basis.P[nn];
+    const double* mode2 = &basis.P[2 * nn];
+    for (std::size_t t = 0; t < nn; ++t) {
+        // Deliberately NOT mode-aligned: both planes excite several modes, so
+        // the superposition claim is tested on genuinely overlapping forcing.
+        spread_a[t] = 0.5 * mode0[t] + 0.2 * mode2[t];
+        spread_b[t] = 0.3 * mode1[t] + 0.4 * mode2[t];
+    }
+
+    auto run = [&](const double* sa, DistType fa,
+                   const double* sb, DistType fb) {
+        SpectralROM1D rom;
+        rom.basis = &basis;
+        rom.n_ensemble = 15;
+        rom.mannings_pert = 0.0;
+        rom.runoff_pert = 0.0;
+        rom.mode_drop_threshold = 0.0;   // all modes active in every run
+        rom.initialize();
+        rom.seed(h_det.data());
+        rom.setSoftForcing(nullptr, sa, fa, nullptr, sb, fb);
+        rom.advance(2.0, 0.5, h_det.data(), nullptr, h_det.data());
+        return rom;
+    };
+
+    SpectralROM1D both = run(spread_a.data(), DistType::NORMAL,
+                             spread_b.data(), DistType::UNIFORM);
+    SpectralROM1D only_a = run(spread_a.data(), DistType::NORMAL, nullptr,
+                               DistType::UNIFORM);
+    SpectralROM1D only_b = run(spread_b.data(), DistType::UNIFORM, nullptr,
+                               DistType::UNIFORM);
+
+    for (std::size_t i = 0; i < both.a_ensemble.size(); ++i)
+        EXPECT_NEAR(both.a_ensemble[i],
+                    only_a.a_ensemble[i] + only_b.a_ensemble[i], 1.0e-14)
+            << "member/mode flat index " << i;
+
+    // And against a fully independent closed form, so the test is not just the
+    // ROM agreeing with itself.
+    const auto nk = static_cast<std::size_t>(both.n_kept);
+    for (int i = 0; i < both.n_ensemble; ++i) {
+        const auto ui = static_cast<std::size_t>(i);
+        for (std::size_t j = 0; j < nk; ++j) {
+            const double g = both.softCoeff()[ui]  * both.soft_r_spread_[j]
+                           + both.softCoeffB()[ui] * both.soft_r_spread_b_[j];
+            const double rate = basis.eigenvalues[j] * 0.5;   // lambda * K1d, mm = 1
+            EXPECT_NEAR(both.a_ensemble[ui * nk + j],
+                        analyticStepFromZero(g, rate, 2.0), 1.0e-13)
+                << "member " << i << " mode " << j;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Multi-gage mixed families (SR-1b's fallback, removed): two disjoint node
+// groups carrying different families both contribute a real band, with no
+// first-family fallback and no warning.
+// ---------------------------------------------------------------------------
+
+TEST(SoftForcingFamilyPlanes, TwoGageMixedFamiliesBothContributeNoFallback) {
+    CsrGraph L = make_chain_laplacian(10);
+    GraphEigenBasis basis;
+    ASSERT_TRUE(basis.build(L, 4));
+
+    const auto nn = static_cast<std::size_t>(basis.n_nodes);
+    std::vector<double> h_det(nn, 0.0);
+    // Gage A serves the upstream half (NORMAL), gage B the downstream half
+    // (UNIFORM) -- disjoint supports, exactly how a multi-gage source splits.
+    // Unequal spreads on purpose: with EQUAL spreads the two complementary
+    // halves project onto every (zero-mean) eigenmode with exactly opposite
+    // signs, so the fallback reference below would collapse to a degenerate
+    // zero band and the comparison would prove less than it appears.
+    std::vector<double> spread_a(nn, 0.0), spread_b(nn, 0.0);
+    for (std::size_t t = 0; t < nn; ++t) {
+        if (t < nn / 2) spread_a[t] = 0.60;
+        else            spread_b[t] = 0.35;
+    }
+
+    SpectralROM1D rom;
+    rom.basis = &basis;
+    rom.n_ensemble = 21;
+    rom.mannings_pert = 0.0;
+    rom.runoff_pert = 0.0;
+    rom.initialize();
+    rom.seed(h_det.data());
+    rom.setSoftForcing(nullptr, spread_a.data(), DistType::NORMAL, nullptr,
+                       spread_b.data(), DistType::UNIFORM);
+
+    // No fallback: the second family is honoured, not collapsed onto the first.
+    EXPECT_TRUE(rom.softPlanesError().empty()) << rom.softPlanesError();
+    ASSERT_EQ(static_cast<int>(rom.softCoeffB().size()), rom.n_ensemble);
+
+    rom.advance(1.0, 0.5, h_det.data(), nullptr, h_det.data());
+    rom.computeQuantiles(h_det.data(), nullptr);
+
+    // Both gages' spreads reach the modal forcing.
+    double abs_a = 0.0, abs_b = 0.0;
+    for (int j = 0; j < rom.n_kept; ++j) {
+        abs_a = std::max(abs_a, std::abs(rom.soft_r_spread_[static_cast<std::size_t>(j)]));
+        abs_b = std::max(abs_b, std::abs(rom.soft_r_spread_b_[static_cast<std::size_t>(j)]));
+    }
+    EXPECT_GT(abs_a, 1.0e-6);
+    EXPECT_GT(abs_b, 1.0e-6);
+
+    // A real band forms, and the median still tracks the deterministic run.
+    double widest = 0.0;
+    for (std::size_t t = 0; t < nn; ++t)
+        widest = std::max(widest, rom.q95[t] - rom.q05[t]);
+    EXPECT_GT(widest, 1.0e-6);
+    for (std::size_t t = 0; t < nn; ++t)
+        EXPECT_NEAR(rom.q50[t], 0.0, 1.0e-12) << "node " << t;
+
+    // The decisive comparison: reproduce SR-1b's REMOVED first-family fallback
+    // -- every gage forced onto gage A's family, i.e. one NORMAL plane over the
+    // summed spread -- and require the per-family answer to differ materially
+    // from it. This is what "no longer falls back to the first family" means
+    // operationally.
+    //
+    // NOTE (real property, not a defect): the per-family band here is NARROWER
+    // than the fallback's, not wider. Comonotone coherence gives every member
+    // the same rank in both families, and two gages on complementary parts of
+    // the network project onto the shared eigenmodes with opposing signs, so
+    // their contributions partially cancel. Adding a second family plane is
+    // therefore not monotone in band width -- asserting "wider" would be
+    // asserting a coincidence of the fixture.
+    std::vector<double> spread_sum(nn, 0.0);
+    for (std::size_t t = 0; t < nn; ++t)
+        spread_sum[t] = spread_a[t] + spread_b[t];
+
+    SpectralROM1D fallback;
+    fallback.basis = &basis;
+    fallback.n_ensemble = 21;
+    fallback.mannings_pert = 0.0;
+    fallback.runoff_pert = 0.0;
+    fallback.initialize();
+    fallback.seed(h_det.data());
+    fallback.setSoftForcing(nullptr, spread_sum.data(), DistType::NORMAL);
+    fallback.advance(1.0, 0.5, h_det.data(), nullptr, h_det.data());
+    fallback.computeQuantiles(h_det.data(), nullptr);
+
+    double widest_fb = 0.0;
+    for (std::size_t t = 0; t < nn; ++t)
+        widest_fb = std::max(widest_fb, fallback.q95[t] - fallback.q05[t]);
+    EXPECT_GT(widest_fb, 1.0e-6);
+
+    // Materially different -- gage B's UNIFORM marginal is genuinely in play,
+    // not absorbed into gage A's NORMAL column.
+    EXPECT_GT(std::abs(widest - widest_fb) / widest_fb, 0.05)
+        << "per-family band " << widest << " vs first-family fallback "
+        << widest_fb;
+}
+
+// ---------------------------------------------------------------------------
+// Scope guard: CORR_LEN x MIXED is refused with a clear message, and the ROM
+// stays in a valid single-family CORR_LEN state rather than half-configured.
+// ---------------------------------------------------------------------------
+
+TEST(SoftForcingFamilyPlanes, CorrLenTimesMixedIsRefusedNotSilentlyMixed) {
+    CsrGraph L = make_chain_laplacian(8);
+    GraphEigenBasis basis;
+    ASSERT_TRUE(basis.build(L, 4));
+
+    const auto nn = static_cast<std::size_t>(basis.n_nodes);
+    std::vector<double> h_det(nn, 0.0), spread_a(nn), spread_b(nn);
+    const double* mode0 = &basis.P[0];
+    const double* mode1 = &basis.P[nn];
+    for (std::size_t t = 0; t < nn; ++t) {
+        spread_a[t] = 0.5 * mode0[t];
+        spread_b[t] = 0.5 * mode1[t];
+    }
+
+    SpectralROM1D rom;
+    rom.basis = &basis;
+    rom.n_ensemble = 11;
+    rom.mannings_pert = 0.0;
+    rom.runoff_pert = 0.0;
+    rom.initialize();
+    rom.seed(h_det.data());
+
+    // Populate soft_coeff_ so the constant-row field can be built, then arm
+    // CORR_LEN and a second family plane together.
+    rom.setSoftForcing(nullptr, spread_a.data(), DistType::NORMAL);
+    SoftSpatialField field = makeConstantRowField(rom, basis.n_nodes);
+    rom.setSoftForcing(nullptr, spread_a.data(), DistType::NORMAL, &field,
+                       spread_b.data(), DistType::UNIFORM);
+
+    EXPECT_FALSE(rom.softPlanesError().empty());
+    EXPECT_NE(rom.softPlanesError().find("CORR_LEN"), std::string::npos);
+    EXPECT_TRUE(rom.softCoeffB().empty());
+
+    // Behaviour is exactly the single-family CORR_LEN run, not a half-applied
+    // second plane.
+    rom.advance(1.0, 0.5, h_det.data(), nullptr, h_det.data());
+
+    SpectralROM1D ref;
+    ref.basis = &basis;
+    ref.n_ensemble = 11;
+    ref.mannings_pert = 0.0;
+    ref.runoff_pert = 0.0;
+    ref.initialize();
+    ref.seed(h_det.data());
+    ref.setSoftForcing(nullptr, spread_a.data(), DistType::NORMAL);
+    SoftSpatialField ref_field = makeConstantRowField(ref, basis.n_nodes);
+    ref.setSoftForcing(nullptr, spread_a.data(), DistType::NORMAL, &ref_field);
+    ref.advance(1.0, 0.5, h_det.data(), nullptr, h_det.data());
+
+    for (std::size_t i = 0; i < ref.a_ensemble.size(); ++i)
+        EXPECT_EQ(rom.a_ensemble[i], ref.a_ensemble[i]) << "flat index " << i;
+
+    // A later single-family call clears the error -- it is per-call state.
+    rom.setSoftForcing(nullptr, spread_a.data(), DistType::NORMAL);
+    EXPECT_TRUE(rom.softPlanesError().empty());
+}
+
+// ---------------------------------------------------------------------------
+// 2D: the checkerboard MIXED grid the SR-4b hack was written for. Cells
+// alternate NORMAL/UNIFORM family; each family's cells go into their own plane
+// (zero elsewhere), and the result is checked against an independent analytic
+// per-member reference built from the two coefficient columns.
+// ---------------------------------------------------------------------------
+
+TEST(SoftForcingFamilyPlanes2D, CheckerboardMixedGridUsesBothFamilies) {
+    MeshData mesh = makeStructuredMesh(4, 4.0);
+    MeshEigenBasis basis;
+    ASSERT_TRUE(basis.build(mesh, 6));
+
+    const int nt = basis.n_triangles;
+    const auto unt = static_cast<std::size_t>(nt);
+    std::vector<double> h_det(unt, 0.0);
+    std::vector<double> spread_norm(unt, 0.0), spread_unif(unt, 0.0);
+
+    // /family_code checkerboard: even cells NORMAL, odd cells UNIFORM. Each
+    // plane holds only its own cells' spread; the two are disjoint and sum to
+    // the full spread field, which is exactly the split H7 introduces.
+    const double* mode0 = &basis.P[0];
+    for (int t = 0; t < nt; ++t) {
+        const auto ut = static_cast<std::size_t>(t);
+        const double sp = 0.05 + 0.2 * std::abs(mode0[t]);
+        if (t % 2 == 0) spread_norm[ut] = sp;
+        else            spread_unif[ut] = sp;
+    }
+
+    SpectralROM rom;
+    rom.basis = &basis;
+    rom.n_ensemble = 21;
+    rom.mannings_pert = 0.0;
+    rom.rainfall_pert = 0.0;
+    rom.mode_drop_threshold = 0.0;
+    rom.initialize();
+    rom.seed(h_det.data());
+    rom.setSoftForcing(nullptr, spread_norm.data(), DistType::NORMAL, nullptr,
+                       spread_unif.data(), DistType::UNIFORM);
+
+    ASSERT_TRUE(rom.softPlanesError().empty()) << rom.softPlanesError();
+    ASSERT_EQ(static_cast<int>(rom.softCoeffB().size()), rom.n_ensemble);
+    EXPECT_TRUE(sameRankOrder(rom.softCoeff(), rom.softCoeffB()));
+
+    const double dt = 1.0;
+    rom.advance(dt, 0.0, nullptr, nullptr, h_det.data());
+    rom.computeQuantiles(h_det.data());
+
+    // Independent reference: project each plane by hand off the basis and
+    // integrate the modal ODE in closed form, per member.
+    const auto nk = static_cast<std::size_t>(rom.n_kept);
+    std::vector<double> RA(nk, 0.0), RB(nk, 0.0);
+    for (std::size_t j = 0; j < nk; ++j) {
+        const double* Pj = &basis.P[j * unt];
+        for (std::size_t t = 0; t < unt; ++t) {
+            RA[j] += Pj[t] * spread_norm[t];
+            RB[j] += Pj[t] * spread_unif[t];
+        }
+    }
+    // Both families genuinely reach the modal forcing.
+    double maxA = 0.0, maxB = 0.0;
+    for (std::size_t j = 0; j < nk; ++j) {
+        maxA = std::max(maxA, std::abs(RA[j]));
+        maxB = std::max(maxB, std::abs(RB[j]));
+    }
+    EXPECT_GT(maxA, 1.0e-6);
+    EXPECT_GT(maxB, 1.0e-6);
+
+    for (int i = 0; i < rom.n_ensemble; ++i) {
+        const auto ui = static_cast<std::size_t>(i);
+        const double cA = rom.softCoeff()[ui];
+        const double cB = rom.softCoeffB()[ui];
+        for (std::size_t j = 0; j < nk; ++j) {
+            // K_eff = 0 here (no Manning channel), so rate = 0 -> Euler branch.
+            const double expected = analyticStepFromZero(cA * RA[j] + cB * RB[j],
+                                                         0.0, dt);
+            EXPECT_NEAR(rom.a_ensemble[ui * nk + j], expected, 1.0e-13)
+                << "member " << i << " mode " << j;
+        }
+    }
+
+    // A real band, and the median still tracks the deterministic field.
+    double widest = 0.0;
+    for (std::size_t t = 0; t < unt; ++t)
+        widest = std::max(widest, rom.q95[t] - rom.q05[t]);
+    EXPECT_GT(widest, 1.0e-6);
+    for (std::size_t t = 0; t < unt; ++t)
+        EXPECT_NEAR(rom.q50[t], 0.0, 1.0e-12) << "cell " << t;
+}
+
+// 2D regression lock, mirroring the 1D one.
+TEST(SoftForcingFamilyPlanes2D, NullAndZeroSecondPlaneAreBitIdentical) {
+    MeshData mesh = makeStructuredMesh();
+    MeshEigenBasis basis;
+    ASSERT_TRUE(basis.build(mesh, 6));
+
+    const int nt = basis.n_triangles;
+    const auto unt = static_cast<std::size_t>(nt);
+    std::vector<double> h_det(unt, 0.0), loc(unt), spread(unt);
+    std::vector<double> zero_plane(unt, 0.0);
+    const double* mode0 = &basis.P[0];
+    const double* mode1 = &basis.P[unt];
+    for (std::size_t t = 0; t < unt; ++t) {
+        loc[t]    = mode0[t];
+        spread[t] = 0.3 * mode0[t] + 0.2 * mode1[t];
+    }
+
+    auto run = [&](const double* second) {
+        SpectralROM rom;
+        rom.basis = &basis;
+        rom.n_ensemble = 11;
+        rom.mannings_pert = 0.0;
+        rom.rainfall_pert = 0.0;
+        rom.initialize();
+        rom.seed(h_det.data());
+        rom.setSoftForcing(loc.data(), spread.data(), DistType::NORMAL,
+                           nullptr, second, DistType::UNIFORM);
+        rom.advance(1.0, 0.0, nullptr, nullptr, h_det.data());
+        rom.computeQuantiles(h_det.data());
+        return rom;
+    };
+
+    SpectralROM none = run(nullptr);
+    SpectralROM zero = run(zero_plane.data());
+
+    ASSERT_EQ(none.n_modes_active, zero.n_modes_active);
+    for (std::size_t i = 0; i < none.a_ensemble.size(); ++i)
+        EXPECT_EQ(none.a_ensemble[i], zero.a_ensemble[i]) << "flat index " << i;
+    for (std::size_t t = 0; t < unt; ++t) {
+        EXPECT_EQ(none.q05[t], zero.q05[t]);
+        EXPECT_EQ(none.q50[t], zero.q50[t]);
+        EXPECT_EQ(none.q95[t], zero.q95[t]);
+    }
+}


### PR DESCRIPTION
Adds a second, optional coefficient plane to the soft-rainfall ROM on both 1D and 2D, so a source with mixed distribution families (e.g. some cells/gauges Normal, some Uniform) keeps each family's actual shape instead of borrowing one family's coefficient and range-matching the rest with a ×3.0 fudge. Single-family callers are unaffected — bit-identical, locked with EXPECT_EQ.

Both coefficient columns draw from the same per-member random stream, so the two families stay coherent (same member = same relative rank everywhere) by construction, not convention.

Scope note: the two removals the original spec called for (SR-4b's ×3.0 pre-scale, SR-1b's first-family fallback) don't exist on this branch — that plumbing was never carried over in the port. This PR ships the capability that makes them unnecessary and documents exactly what a future SR port should call instead (VALIDATION.md §5).

Also included: a sweep of every dormant test file in the repo (present on disk, never registered in CMake). 112 previously-unrun tests are now running — all pass. Surfaced two engine source files that were compiled into nothing (RunoffEnsemble.cpp, SpdeSpatialBasis.cpp); both now exercised via dedicated test targets without pre-empting the decision to link them into the engine proper.

Gate: 136/136 minus the one pre-existing, already-documented red (regression_rom_coverage), numerically unmoved.