### PR TITLE
feat(fv): fuse cross-section closure evaluation into closureAll()

### DIFF
--- a/src/engine/hydraulics/fv/ExplicitFvSolver.cpp
+++ b/src/engine/hydraulics/fv/ExplicitFvSolver.cpp
@@ -488,10 +488,11 @@ double ExplicitFvSolver::censusDt() const {
                 const double hg = state_->node_head[static_cast<std::size_t>(nd)] -
                                   mesh_->face_zb[uf];
                 if (hg > k::kDryDepth) {
-                    const double ag = k::areaOfDepth(g, hg);
+                    double ag, wg, rg, i1g;
+                    k::closureAll(g, hg, &ag, &wg, &rg, &i1g);
                     speed = std::max(speed,
                                      std::fabs(cell_u_[uo]) +
-                                         k::celerity(ag, k::widthOfDepth(g, hg)));
+                                         k::celerity(ag, wg));
                 }
             }
         }
@@ -876,8 +877,12 @@ void ExplicitFvSolver::faceSide(int face, int cell, int node, double zstar,
     // i1_raw stays in the CELL's own section — it is the cell's true
     // hydrostatic moment, and the difference from the reconstructed one is the
     // correction that puts the balance back (computeFaceFlux).
-    i1_raw = (h_raw > k::kDryDepth)
-                 ? k::i1OfDepth(*g, h_raw, k::areaOfDepth(*g, h_raw)) : 0.0;
+    if (h_raw > k::kDryDepth) {
+        double a_raw, w_raw, r_raw;
+        k::closureAll(*g, h_raw, &a_raw, &w_raw, &r_raw, &i1_raw);
+    } else {
+        i1_raw = 0.0;
+    }
 
     const double h_star = std::max(0.0, eta - zstar);
     if (h_star <= k::kDryDepth) {
@@ -887,11 +892,11 @@ void ExplicitFvSolver::faceSide(int face, int cell, int node, double zstar,
     // …while the reconstructed state is evaluated in the FACE's section, which
     // both sides share. Where they are the same section (every prismatic face)
     // this is the identical computation.
-    out.a  = k::areaOfDepth(*gf, h_star);
+    double w_star, r_star;
+    k::closureAll(*gf, h_star, &out.a, &w_star, &r_star, &out.i1);
     out.u  = u;
     out.q  = out.a * u;
-    out.c  = k::celerity(out.a, k::widthOfDepth(*gf, h_star));
-    out.i1 = k::i1OfDepth(*gf, h_star, out.a);
+    out.c  = k::celerity(out.a, w_star);
 }
 
 void ExplicitFvSolver::computeFluxes() {
@@ -1215,8 +1220,8 @@ void ExplicitFvSolver::relaxOneNode(int n, double dt,
                     mesh_->geom[static_cast<std::size_t>(mesh_->cell_geom[uc])];
                 const double hg = h_k - mesh_->face_zb[uf];
                 if (hg <= k::kDryDepth) continue;
-                const double ag = k::areaOfDepth(g, hg);
-                const double tg = k::widthOfDepth(g, hg);
+                double ag, tg, rg, i1g;
+                k::closureAll(g, hg, &ag, &tg, &rg, &i1g);
                 if (ag <= k::kDryArea || tg <= 0.0) continue;
                 resist += std::sqrt(k::kGravity * ag * tg);
             }
@@ -1289,8 +1294,8 @@ void ExplicitFvSolver::relaxOneNode(int n, double dt,
                     mesh_->geom[static_cast<std::size_t>(mesh_->cell_geom[uc])];
                 const double hg = h_k - mesh_->face_zb[uf];
                 if (hg <= k::kDryDepth) continue;
-                const double ag = k::areaOfDepth(g, hg);
-                const double tg = k::widthOfDepth(g, hg);
+                double ag, tg, rg, i1g;
+                k::closureAll(g, hg, &ag, &tg, &rg, &i1g);
                 if (ag <= k::kDryArea || tg <= 0.0) continue;
                 // β = −sign·√(gAT): the node on a face's LEFT exports on a
                 // positive flux, the node on its RIGHT imports, and raising the
@@ -1385,8 +1390,15 @@ void ExplicitFvSolver::updateCells(double dt, const FvStepForcing& forcing) {
             const double eta_c = cell_eta_[uc];
             const double hp = std::max(0.0, eta_c - zp);
             const double hm = std::max(0.0, eta_c - zm);
-            const double i1p = (hp > 0.0) ? k::i1OfDepth(g, hp, k::areaOfDepth(g, hp)) : 0.0;
-            const double i1m = (hm > 0.0) ? k::i1OfDepth(g, hm, k::areaOfDepth(g, hm)) : 0.0;
+            double i1p = 0.0, i1m = 0.0;
+            if (hp > 0.0) {
+                double ap, wp, rp;
+                k::closureAll(g, hp, &ap, &wp, &rp, &i1p);
+            }
+            if (hm > 0.0) {
+                double am, wm, rm;
+                k::closureAll(g, hm, &am, &wm, &rm, &i1m);
+            }
             dQ += k::kGravity * (i1p - i1m);
         }
 
@@ -1643,8 +1655,8 @@ void ExplicitFvSolver::solveAlgebraicNode(int n, double dt,
                 mesh_->cell_geom[static_cast<std::size_t>(cell)])];
             const double hg = h - mesh_->face_zb[uf];
             if (hg <= k::kDryDepth) continue;
-            const double ag = k::areaOfDepth(g, hg);
-            const double tg = k::widthOfDepth(g, hg);
+            double ag, tg, rg, i1g;
+            k::closureAll(g, hg, &ag, &tg, &rg, &i1g);
             if (ag <= k::kDryArea || tg <= 0.0) continue;
             resist += std::sqrt(k::kGravity * ag * tg);
         }
@@ -2180,9 +2192,9 @@ double ExplicitFvSolver::cellStableDt(int c) const {
         const double hg = state_->node_head[static_cast<std::size_t>(nd)] -
                           mesh_->face_zb[uf];
         if (hg <= k::kDryDepth) continue;
-        speed = std::max(speed, std::fabs(cell_u_[uc]) +
-                                    k::celerity(k::areaOfDepth(g, hg),
-                                                k::widthOfDepth(g, hg)));
+        double ag, wg, rg, i1g;
+        k::closureAll(g, hg, &ag, &wg, &rg, &i1g);
+        speed = std::max(speed, std::fabs(cell_u_[uc]) + k::celerity(ag, wg));
     }
 
     return (speed > 1.0e-12) ? opts_.cfl * dx / speed : 1.0e30;
@@ -2612,8 +2624,15 @@ void ExplicitFvSolver::fireCells(const std::vector<int>& cells, double dt0,
             const double eta_c = cell_eta_[uc];
             const double hp = std::max(0.0, eta_c - zp);
             const double hm = std::max(0.0, eta_c - zm);
-            const double i1p = (hp > 0.0) ? k::i1OfDepth(g, hp, k::areaOfDepth(g, hp)) : 0.0;
-            const double i1m = (hm > 0.0) ? k::i1OfDepth(g, hm, k::areaOfDepth(g, hm)) : 0.0;
+            double i1p = 0.0, i1m = 0.0;
+            if (hp > 0.0) {
+                double ap, wp, rp;
+                k::closureAll(g, hp, &ap, &wp, &rp, &i1p);
+            }
+            if (hm > 0.0) {
+                double am, wm, rm;
+                k::closureAll(g, hm, &am, &wm, &rm, &i1m);
+            }
             dQ_src = k::kGravity * (i1p - i1m) * dt;
         }
 

--- a/src/engine/hydraulics/fv/FvKernels.hpp
+++ b/src/engine/hydraulics/fv/FvKernels.hpp
@@ -216,6 +216,53 @@ OPENSWMM_KERNEL_FN double i1OfDepth(const FvGeometry& g, double h,
 }
 
 /**
+ * @brief Evaluate the full closure at one depth in a single pass.
+ * @details Performs the crown clamp and the slot-taper branch ONCE and returns
+ *          all four closure quantities. Semantically identical to calling
+ *          areaOfDepth/widthOfDepth/hydRadOfDepth/i1OfDepth separately at the
+ *          same `h` — this is a fusion optimization, not a change of
+ *          formulation. `I1` reuses the `A` this call already computed rather
+ *          than recomputing it, exactly as every existing i1OfDepth call site
+ *          already does by hand.
+ * @param g  conduit closure
+ * @param h  depth above invert (ft)
+ * @param[out] A  flow area, including the tapered slot (ft²)
+ * @param[out] W  top width, including the tapered slot (ft)
+ * @param[out] R  hydraulic radius (ft)
+ * @param[out] I1 hydrostatic first moment ∫₀ʰ A(η)dη (ft³)
+ * @note Bit-identical results to the unfused path are REQUIRED. See test F1.
+ */
+OPENSWMM_KERNEL_FN void closureAll(const FvGeometry& g, double h,
+                                   double* A, double* W, double* R,
+                                   double* I1) noexcept {
+    if (h <= 0.0) {
+        *A = 0.0; *W = 0.0; *R = 0.0; *I1 = 0.0;
+        return;
+    }
+    if (h >= g.y_full) {
+        const double d = h - g.y_full;
+        *A  = g.a_crown + g.t_slot * d;
+        *W  = g.t_slot;
+        *R  = g.r_full;
+        *I1 = g.i1_crown + g.a_crown * d + 0.5 * g.t_slot * d * d;
+        return;
+    }
+    const double ax = g.barrel_scale * g.eval->getAofY(g.xs, h);
+    const double wx = g.barrel_scale * g.eval->getWofY(g.xs, h);
+    const double band = g.y_full - g.y_crown;
+    if (band <= 0.0) {
+        *A = ax;
+        *W = wx;
+    } else {
+        const double s = (h - g.y_crown) / band;
+        *A = ax + g.t_slot * band * slotRampIntegral(s);
+        *W = wx + g.t_slot * slotRamp(s);
+    }
+    *R  = g.eval->getRofY(g.xs, h);
+    *I1 = i1OfDepth(g, h, *A);
+}
+
+/**
  * @brief Invert A → h — the EXACT inverse of areaOfDepth above.
  *
  * @details This must be a true inverse, not merely an accurate one. The solver

--- a/tests/unit/engine/test_fv_solver_closure.cpp
+++ b/tests/unit/engine/test_fv_solver_closure.cpp
@@ -222,3 +222,54 @@ TEST(FvClosure, OpenSectionsGetNoSlotAndExtendVertically) {
     for (double h : {1.0, 3.9, 4.0, 4.5, 12.0})
         EXPECT_NEAR(k::areaOfDepth(g, h), 10.0 * h, 1.0e-9);
 }
+
+// ---------------------------------------------------------------------------
+// Phase 1 — fused closure (test F1)
+// ---------------------------------------------------------------------------
+//
+// closureAll() must be a pure fusion of areaOfDepth/widthOfDepth/
+// hydRadOfDepth/i1OfDepth: same inputs in, bit-identical outputs, for every
+// depth regime (dry, below crown, inside the taper band, at the crown exactly,
+// and deep in the slot) and for both tabulated (CIRCULAR) and analytic
+// (RECT_OPEN) sections.
+
+namespace {
+
+void expectClosureAllMatchesUnfused(const FvGeometry& g, double h) {
+    const double a_ref  = k::areaOfDepth(g, h);
+    const double w_ref  = k::widthOfDepth(g, h);
+    const double r_ref  = k::hydRadOfDepth(g, h);
+    const double i1_ref = k::i1OfDepth(g, h, a_ref);
+
+    double a, w, r, i1;
+    k::closureAll(g, h, &a, &w, &r, &i1);
+
+    EXPECT_EQ(a, a_ref)   << "A mismatch at h=" << h;
+    EXPECT_EQ(w, w_ref)   << "W mismatch at h=" << h;
+    EXPECT_EQ(r, r_ref)   << "R mismatch at h=" << h;
+    EXPECT_EQ(i1, i1_ref) << "I1 mismatch at h=" << h;
+}
+
+} // namespace
+
+TEST(FvClosure, F1_ClosureAllIsBitIdenticalToUnfusedPath_Circular) {
+    const FvGeometry g = makeCircular(3.0);
+    expectClosureAllMatchesUnfused(g, 0.0);
+    expectClosureAllMatchesUnfused(g, -1.0);       // dry, negative depth
+    for (int i = 0; i <= 4000; ++i) {
+        const double h = g.y_full * 2.0 * static_cast<double>(i) / 4000.0;
+        expectClosureAllMatchesUnfused(g, h);
+    }
+    expectClosureAllMatchesUnfused(g, g.y_crown);   // exactly at the taper start
+    expectClosureAllMatchesUnfused(g, g.y_full);    // exactly at the crown
+}
+
+TEST(FvClosure, F1_ClosureAllIsBitIdenticalToUnfusedPath_OpenRect) {
+    const FvGeometry g = makeRect(10.0, 4.0);
+    expectClosureAllMatchesUnfused(g, 0.0);
+    for (int i = 0; i <= 4000; ++i) {
+        const double h = g.y_full * 3.0 * static_cast<double>(i) / 4000.0;
+        expectClosureAllMatchesUnfused(g, h);
+    }
+    expectClosureAllMatchesUnfused(g, g.y_full);
+}


### PR DESCRIPTION
areaOfDepth/widthOfDepth/hydRadOfDepth/i1OfDepth were each independently re-checking the dry/crown clamp and recomputing the slot-taper band at the same depth h. Add closureAll(g, h, &A, &W, &R, &I1) to FvKernels.hpp, which does that work once, and route every call site in ExplicitFvSolver that needs 2+ quantities at the same h through it (the per-face hydrostatic reconstruction, node Picard/algebraic resistance sweeps, the second-order bed-source term, and LTS tiering).

Verified bit-identical: new test F1 checks exact equality against the unfused path at every depth regime, and a full FV run of Example1 under FLOW_ROUTING FV produces a byte-for-byte identical .out file before and after. Pre-existing failures in fv_integration and xsect_kernels_parity (confirmed present on unmodified swmm6_rel) are unrelated last-ulp float noise.