### PR TITLE
feat(hydraulics): exact circular-arc/line boundary primitives (XSectB…

### DIFF
--- a/src/engine/hydraulics/XSectBoundary.cpp
+++ b/src/engine/hydraulics/XSectBoundary.cpp
@@ -1,0 +1,423 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Copyright 2026 Caleb Buahin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file XSectBoundary.cpp
+ * @ingroup engine_hydraulics
+ */
+
+#include "XSectBoundary.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+namespace openswmm::xsboundary {
+
+namespace {
+
+constexpr double kTwoPi = 2.0 * M_PI;
+
+bool allFinite(const double* a, int n) noexcept {
+    for (int i = 0; i < n; ++i) {
+        if (!std::isfinite(a[i])) return false;
+    }
+    return true;
+}
+
+/// Angles (within one sweep of @p e, magnitude <= 2*pi) where sin(theta) ==
+/// (y-cy)/r, i.e. where the arc's own y(theta) crosses @p y. Ascending order.
+int arcCrossingAngles(const BElem& e, double y, double theta_out[2]) noexcept {
+    const double s = (y - e.cy) / e.radius;
+    if (s < -1.0 || s > 1.0) return 0;
+
+    const double lo = std::min(e.a0, e.a1);
+    const double hi = std::max(e.a0, e.a1);
+    const double clamped = std::clamp(s, -1.0, 1.0);
+    const double thetaA = std::asin(clamped);   // in [-pi/2, pi/2]
+    const double thetaB = M_PI - thetaA;         // in [pi/2, 3pi/2]
+
+    int count = 0;
+    double found[2] = {0.0, 0.0};
+    for (double base : {thetaA, thetaB}) {
+        const double kmin = std::ceil((lo - base) / kTwoPi - 1.0e-12);
+        const double kmax = std::floor((hi - base) / kTwoPi + 1.0e-12);
+        for (double k = kmin; k <= kmax; k += 1.0) {
+            const double theta = base + k * kTwoPi;
+            if (theta < lo - 1.0e-12 || theta > hi + 1.0e-12) continue;
+            bool dup = false;
+            for (int j = 0; j < count; ++j) {
+                if (std::fabs(found[j] - theta) < 1.0e-9) { dup = true; break; }
+            }
+            if (!dup && count < 2) found[count++] = theta;
+        }
+    }
+    if (count == 2 && found[0] > found[1]) std::swap(found[0], found[1]);
+    theta_out[0] = found[0];
+    theta_out[1] = found[1];
+    return count;
+}
+
+/// True minimum y over the whole element, including an arc's interior low
+/// point (theta == -pi/2 mod 2*pi) when that angle falls within its sweep —
+/// not just its two endpoints.
+double elemMinY(const BElem& e) noexcept {
+    if (e.radius == 0.0) return std::min(e.y0, e.y1);
+    double m = std::min(e.y0, e.y1);
+    const double lo = std::min(e.a0, e.a1);
+    const double hi = std::max(e.a0, e.a1);
+    const double base = -0.5 * M_PI;
+    const auto kmin = static_cast<long>(std::floor((lo - base) / kTwoPi)) - 1;
+    const auto kmax = static_cast<long>(std::ceil((hi - base) / kTwoPi)) + 1;
+    for (long k = kmin; k <= kmax; ++k) {
+        const double theta = base + static_cast<double>(k) * kTwoPi;
+        if (theta >= lo - 1.0e-12 && theta <= hi + 1.0e-12) {
+            m = std::min(m, e.cy - e.radius);
+        }
+    }
+    return m;
+}
+
+int orientation(double ax, double ay, double bx, double by,
+                double cx, double cy) noexcept {
+    const double v = (bx - ax) * (cy - ay) - (by - ay) * (cx - ax);
+    if (v > 1.0e-12) return 1;
+    if (v < -1.0e-12) return -1;
+    return 0;
+}
+
+bool onSegment(double ax, double ay, double bx, double by,
+               double px, double py) noexcept {
+    return std::min(ax, bx) - 1.0e-9 <= px && px <= std::max(ax, bx) + 1.0e-9 &&
+           std::min(ay, by) - 1.0e-9 <= py && py <= std::max(ay, by) + 1.0e-9;
+}
+
+/// Standard orientation-based segment/segment intersection test (chords only
+/// — arcs are approximated by their chords here, as the spec permits for
+/// this O(n^2) build-time check).
+bool segmentsIntersect(double ax, double ay, double bx, double by,
+                       double cx, double cy, double dx, double dy) noexcept {
+    const int o1 = orientation(ax, ay, bx, by, cx, cy);
+    const int o2 = orientation(ax, ay, bx, by, dx, dy);
+    const int o3 = orientation(cx, cy, dx, dy, ax, ay);
+    const int o4 = orientation(cx, cy, dx, dy, bx, by);
+    if (o1 != o2 && o3 != o4) return true;
+    if (o1 == 0 && onSegment(ax, ay, bx, by, cx, cy)) return true;
+    if (o2 == 0 && onSegment(ax, ay, bx, by, dx, dy)) return true;
+    if (o3 == 0 && onSegment(cx, cy, dx, dy, ax, ay)) return true;
+    if (o4 == 0 && onSegment(cx, cy, dx, dy, bx, by)) return true;
+    return false;
+}
+
+/// Builds the closed n-element chain from points + optional DXF bulges, with
+/// no validation and no reorientation — the shared core of fromArcSpec()'s
+/// first build and its rebuild-after-reversal.
+void buildChain(const double* x, const double* y, const double* bulge, int n,
+                std::vector<BElem>& out) {
+    out.clear();
+    out.reserve(static_cast<std::size_t>(n));
+    for (int i = 0; i < n; ++i) {
+        const int j = (i + 1) % n;
+        const double x0 = x[i], y0 = y[i], x1 = x[j], y1 = y[j];
+        const double b = bulge ? bulge[i] : 0.0;
+
+        BElem e{};
+        e.x0 = x0; e.y0 = y0; e.x1 = x1; e.y1 = y1;
+
+        if (b != 0.0) {
+            const double dx = x1 - x0, dy = y1 - y0;
+            const double c = std::sqrt(dx * dx + dy * dy);
+            const double theta = 4.0 * std::atan(b);
+            const double r = c / (2.0 * std::fabs(std::sin(0.5 * theta)));
+            const double mx = 0.5 * (x0 + x1), my = 0.5 * (y0 + y1);
+            const double nx = -dy / c, ny = dx / c;   // unit normal, left of p0->p1
+            const double sagitta = r * std::cos(0.5 * theta);
+            const double sgn = (b > 0.0) ? 1.0 : -1.0;
+            const double cx = mx + sgn * sagitta * nx;
+            const double cy = my + sgn * sagitta * ny;
+            const double a0 = std::atan2(y0 - cy, x0 - cx);
+
+            e.cx = cx; e.cy = cy; e.radius = r;
+            e.a0 = a0; e.a1 = a0 + theta;
+        }
+        out.push_back(e);
+    }
+}
+
+} // namespace
+
+// ===========================================================================
+// Green's theorem primitives
+// ===========================================================================
+
+double greenArea(const BElem& e) noexcept {
+    if (e.radius == 0.0) {
+        return 0.5 * (e.x0 * e.y1 - e.x1 * e.y0);
+    }
+    const double r = e.radius;
+    return 0.5 * (r * r * (e.a1 - e.a0) +
+                  r * (e.cx * (std::sin(e.a1) - std::sin(e.a0)) -
+                       e.cy * (std::cos(e.a1) - std::cos(e.a0))));
+}
+
+double greenMomentY(const BElem& e) noexcept {
+    if (e.radius == 0.0) {
+        return -0.5 * (e.x1 - e.x0) *
+               (e.y0 * e.y0 + e.y0 * e.y1 + e.y1 * e.y1) / 3.0;
+    }
+    const double r = e.radius, cy = e.cy;
+    auto F = [cy, r](double t) {
+        const double c = std::cos(t);
+        return cy * cy * (-c) +
+               2.0 * cy * r * (0.5 * t - 0.25 * std::sin(2.0 * t)) +
+               r * r * (-c + c * c * c / 3.0);
+    };
+    return (r / 2.0) * (F(e.a1) - F(e.a0));
+}
+
+double arcLength(const BElem& e) noexcept {
+    if (e.radius == 0.0) {
+        const double dx = e.x1 - e.x0, dy = e.y1 - e.y0;
+        return std::sqrt(dx * dx + dy * dy);
+    }
+    return e.radius * std::fabs(e.a1 - e.a0);
+}
+
+// ===========================================================================
+// Height queries
+// ===========================================================================
+
+int crossingsAt(const BElem& e, double y, double xout[2]) noexcept {
+    if (e.radius == 0.0) {
+        const double y0 = e.y0, y1 = e.y1;
+        if (y0 == y1) return 0;
+        // Half-open on the element's OWN endpoint order so a scanline through
+        // a shared vertex between two consecutive elements is not double
+        // counted.
+        const bool crosses = (y0 <= y && y < y1) || (y1 <= y && y < y0);
+        if (!crosses) return 0;
+        const double t = (y - y0) / (y1 - y0);
+        xout[0] = e.x0 + t * (e.x1 - e.x0);
+        return 1;
+    }
+
+    double theta[2];
+    const int n = arcCrossingAngles(e, y, theta);
+    for (int i = 0; i < n; ++i) {
+        xout[i] = e.cx + e.radius * std::cos(theta[i]);
+    }
+    return n;
+}
+
+int clipBelow(const BElem& e, double y, BElem out[2]) noexcept {
+    if (e.radius == 0.0) {
+        const bool below0 = e.y0 <= y;
+        const bool below1 = e.y1 <= y;
+        if (below0 && below1) { out[0] = e; return 1; }
+        if (!below0 && !below1) return 0;
+
+        const double t = (y - e.y0) / (e.y1 - e.y0);
+        const double xc = e.x0 + t * (e.x1 - e.x0);
+        BElem r{};
+        if (below0) { r.x0 = e.x0; r.y0 = e.y0; r.x1 = xc;   r.y1 = y; }
+        else        { r.x0 = xc;   r.y0 = y;    r.x1 = e.x1; r.y1 = e.y1; }
+        out[0] = r;
+        return 1;
+    }
+
+    double theta[2];
+    const int nc = arcCrossingAngles(e, y, theta);
+    const double lo = std::min(e.a0, e.a1);
+    const double hi = std::max(e.a0, e.a1);
+    const double dir = (e.a1 >= e.a0) ? 1.0 : -1.0;
+
+    double bounds[4];
+    int nb = 0;
+    bounds[nb++] = lo;
+    for (int i = 0; i < nc; ++i) bounds[nb++] = theta[i];
+    bounds[nb++] = hi;
+
+    int count = 0;
+    for (int i = 0; i + 1 < nb && count < 2; ++i) {
+        const double s0 = bounds[i], s1 = bounds[i + 1];
+        if (s1 - s0 < 1.0e-13) continue;              // degenerate (tangent) sliver
+        const double mid = 0.5 * (s0 + s1);
+        const double ymid = e.cy + e.radius * std::sin(mid);
+        if (ymid > y) continue;                        // this sub-arc is above the cut
+
+        BElem r{};
+        r.cx = e.cx; r.cy = e.cy; r.radius = e.radius;
+        if (dir > 0.0) { r.a0 = s0; r.a1 = s1; }
+        else           { r.a0 = s1; r.a1 = s0; }
+        r.x0 = e.cx + e.radius * std::cos(r.a0);
+        r.y0 = e.cy + e.radius * std::sin(r.a0);
+        r.x1 = e.cx + e.radius * std::cos(r.a1);
+        r.y1 = e.cy + e.radius * std::sin(r.a1);
+        out[count++] = r;
+    }
+    return count;
+}
+
+// ===========================================================================
+// Whole-boundary evaluation
+// ===========================================================================
+
+ExactProps evalExact(const BElem* elems, int n, double y) {
+    ExactProps out;
+    if (n <= 0 || y <= 0.0) return out;
+
+    double area = 0.0, my = 0.0, perim = 0.0;
+    std::vector<double> xs;
+    xs.reserve(static_cast<std::size_t>(n) * 2);
+
+    BElem clipped[2];
+    for (int i = 0; i < n; ++i) {
+        const int nc = clipBelow(elems[i], y, clipped);
+        for (int k = 0; k < nc; ++k) {
+            const BElem& c = clipped[k];
+            area += greenArea(c);
+            my   += greenMomentY(c);
+            // A WALL element lying exactly on the y == level cut (a flat
+            // bench precisely at the query depth) is the free surface, not
+            // wetted perimeter.
+            const bool flatAtSurface = (c.radius == 0.0 && c.y0 == y && c.y1 == y);
+            if (!flatAtSurface) perim += arcLength(c);
+        }
+
+        double xo[2];
+        const int ncr = crossingsAt(elems[i], y, xo);
+        for (int k = 0; k < ncr; ++k) xs.push_back(xo[k]);
+    }
+
+    std::sort(xs.begin(), xs.end());
+
+    // Close each wet span at the free surface with a synthetic horizontal cap
+    // (right crossing -> left crossing, so the whole contour stays CCW) so
+    // the Green's-theorem sums are over CLOSED loops — see the @note on
+    // evalExact() for why this is required, not optional. The cap's own
+    // length is never added to `perim`.
+    double width = 0.0;
+    for (std::size_t i = 0; i + 1 < xs.size(); i += 2) {
+        const double xl = xs[i], xr = xs[i + 1];
+        width += xr - xl;
+        BElem cap{};
+        cap.x0 = xr; cap.y0 = y;
+        cap.x1 = xl; cap.y1 = y;
+        area += greenArea(cap);
+        my   += greenMomentY(cap);
+    }
+
+    out.area  = area;
+    out.perim = perim;
+    out.width = width;
+    out.ybar  = (area > 0.0) ? my / area : 0.0;
+    out.i1    = area * (y - out.ybar);
+    out.ncomp = static_cast<int>(xs.size() / 2);
+    return out;
+}
+
+// ===========================================================================
+// Construction
+// ===========================================================================
+
+int fromPolyline(const double* x, const double* y, int n,
+                 std::vector<BElem>& out) {
+    return fromArcSpec(x, y, nullptr, n, out);
+}
+
+int fromArcSpec(const double* x, const double* y, const double* bulge, int n,
+                std::vector<BElem>& out) {
+    if (n < 3) return static_cast<int>(BoundaryError::TOO_FEW_POINTS);
+    if (!allFinite(x, n) || !allFinite(y, n) ||
+        (bulge != nullptr && !allFinite(bulge, n))) {
+        return static_cast<int>(BoundaryError::NON_FINITE);
+    }
+    if (bulge != nullptr) {
+        for (int i = 0; i < n; ++i) {
+            if (std::fabs(bulge[i]) > 1.0) {
+                return static_cast<int>(BoundaryError::BULGE_TOO_LARGE);
+            }
+        }
+    }
+
+    std::vector<BElem> chain;
+    buildChain(x, y, bulge, n, chain);
+
+    // Simple-polygon check on the chord chain (orientation-independent, so
+    // this need only run once regardless of any reversal below).
+    for (int i = 0; i < n; ++i) {
+        for (int j = i + 1; j < n; ++j) {
+            const bool adjacent = (j == i + 1) || (i == 0 && j == n - 1);
+            if (adjacent) continue;
+            const BElem& ei = chain[static_cast<std::size_t>(i)];
+            const BElem& ej = chain[static_cast<std::size_t>(j)];
+            if (segmentsIntersect(ei.x0, ei.y0, ei.x1, ei.y1,
+                                  ej.x0, ej.y0, ej.x1, ej.y1)) {
+                return static_cast<int>(BoundaryError::SELF_INTERSECTING);
+            }
+        }
+    }
+
+    double area = 0.0;
+    for (const BElem& e : chain) area += greenArea(e);
+    if (std::fabs(area) < 1.0e-12) {
+        return static_cast<int>(BoundaryError::ZERO_AREA);
+    }
+
+    if (area < 0.0) {
+        // Input traced clockwise: reverse the point order AND negate every
+        // bulge (so the same physical arcs are kept, just walked backward),
+        // then rebuild from scratch rather than algebraically flipping the
+        // already-built elements.
+        std::vector<double> rx(static_cast<std::size_t>(n)),
+                            ry(static_cast<std::size_t>(n)),
+                            rb(static_cast<std::size_t>(n), 0.0);
+        for (int k = 0; k < n; ++k) {
+            const int src = (n - k) % n;
+            rx[static_cast<std::size_t>(k)] = x[src];
+            ry[static_cast<std::size_t>(k)] = y[src];
+        }
+        if (bulge != nullptr) {
+            for (int k = 0; k < n; ++k) {
+                const int src = (n - 1 - k) % n;
+                rb[static_cast<std::size_t>(k)] = -bulge[src];
+            }
+        }
+        buildChain(rx.data(), ry.data(), bulge ? rb.data() : nullptr, n, chain);
+    }
+
+    // Shift so the boundary's true minimum y (including any arc's interior
+    // low point, not just its endpoints) lands at 0. A pure vertical
+    // translation leaves every a0/a1 angle unchanged.
+    double y_min = std::numeric_limits<double>::infinity();
+    for (const BElem& e : chain) y_min = std::min(y_min, elemMinY(e));
+    if (std::isfinite(y_min) && y_min != 0.0) {
+        for (BElem& e : chain) {
+            e.y0 -= y_min;
+            e.y1 -= y_min;
+            if (e.radius != 0.0) e.cy -= y_min;
+        }
+    }
+
+    out = std::move(chain);
+    return static_cast<int>(BoundaryError::OK);
+}
+
+} // namespace openswmm::xsboundary

--- a/src/engine/hydraulics/XSectBoundary.hpp
+++ b/src/engine/hydraulics/XSectBoundary.hpp
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Copyright 2026 Caleb Buahin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file XSectBoundary.hpp
+ * @brief Exact circular-arc/line boundary primitives for cross-section geometry.
+ *
+ * @details A cross-section boundary is a closed, CCW-oriented chain of BElem
+ *          (straight line or circular arc) elements. Every quantity needed to
+ *          compile a POLYGON section — area, top width, wetted perimeter, and
+ *          the hydrostatic first moment I1 — is computed EXACTLY from this
+ *          chain via Green's theorem (evalExact), with no depth-quadrature
+ *          anywhere. This is build-time-only machinery: it runs once, when a
+ *          POLYGON section is compiled (see the Chebyshev compiler), not in
+ *          the hot simulation loop, so nothing here is device-tagged.
+ *
+ * @note The Green's theorem formulas below are GIVEN by the design spec,
+ *       already verified against 200 001-point numerical quadrature to
+ *       1e-10, and are transcribed here rather than re-derived.
+ * @ingroup engine_hydraulics
+ *
+ * @author   Caleb Buahin <caleb.buahin@gmail.com>
+ * @copyright Copyright (c) 2026 Caleb Buahin. All rights reserved.
+ * @license  Apache-2.0
+ */
+
+#ifndef OPENSWMM_XSECT_BOUNDARY_HPP
+#define OPENSWMM_XSECT_BOUNDARY_HPP
+
+#include <vector>
+
+namespace openswmm::xsboundary {
+
+/**
+ * @brief One boundary element: a straight line segment or a circular arc.
+ * @details A line has `radius == 0`. An arc runs from `(x0,y0)` at angle `a0`
+ *          to `(x1,y1)` at angle `a1` about `(cx,cy)`:
+ *          `x(t) = cx + r*cos(a0 + t*(a1-a0))`,
+ *          `y(t) = cy + r*sin(a0 + t*(a1-a0))`, `t` in `[0,1]`. The full
+ *          chain is closed and oriented CCW overall so Green's theorem gives
+ *          a positive enclosed area.
+ * @note `a1 > a0` is the common case — a convex, outward-bulging arc walked
+ *       in the CCW boundary direction (the standard positive-DXF-bulge
+ *       shape). `a1 < a0` is valid and REQUIRED for a locally concave arc (a
+ *       notch) walked in the same overall CCW boundary direction: the
+ *       *signed* sweep `a1-a0` must match the boundary's walking direction
+ *       for the Green's-theorem sum over all elements to give the correct
+ *       total area/moment — swapping which endpoint is `a0` vs `a1` negates
+ *       that element's contribution, exactly as swapping a segment's
+ *       endpoints negates `greenArea(segment)`. Every function below is
+ *       written to handle either sign; only `arcLength` takes `|a1-a0|`,
+ *       since a physical length cannot be negative.
+ */
+struct BElem {
+    double x0 = 0.0, y0 = 0.0, x1 = 0.0, y1 = 0.0;
+    double cx = 0.0, cy = 0.0;
+    double radius = 0.0;       ///< 0 = straight segment
+    double a0 = 0.0, a1 = 0.0; ///< arc angle at (x0,y0) and (x1,y1), radians
+};
+
+/// Exact section properties at one depth, from evalExact().
+struct ExactProps {
+    double area  = 0.0; ///< wetted area (ft²)
+    double perim = 0.0; ///< wetted perimeter — WALL elements only, excludes
+                         ///< the free-surface cut (ft)
+    double width = 0.0; ///< top width — sum of the wet spans at depth y (ft)
+    double ybar  = 0.0; ///< centroid height of the wetted area above invert (ft)
+    double i1    = 0.0; ///< hydrostatic first moment A(y)*(y - ybar(y)) (ft³)
+    int    ncomp = 0;   ///< number of disjoint wetted components at this depth
+};
+
+/// Error codes returned by the boundary-construction functions below. 5 and 6
+/// are reserved for the Chebyshev compiler (piece budget exhausted / A(y) not
+/// monotone) and are never returned here; 8 is raised by the [CURVES] row
+/// parser, not by fromArcSpec itself, which takes already-parsed arrays.
+enum class BoundaryError : int {
+    OK                  = 0,
+    TOO_FEW_POINTS      = 1, ///< n < 3
+    SELF_INTERSECTING   = 2, ///< non-adjacent chords cross
+    ZERO_AREA           = 3, ///< |signed area| below tolerance
+    NON_FINITE          = 4, ///< a NaN/Inf coordinate or bulge
+    BULGE_TOO_LARGE     = 7, ///< |bulge| > 1 (arc sweep would exceed pi)
+    MALFORMED_CURVE_ROW = 8, ///< raised by the [CURVES] text parser, not here
+};
+
+// ===========================================================================
+// Green's theorem primitives — exact, no quadrature
+// ===========================================================================
+
+/// Signed contribution to the enclosed area, 0.5*(x dy - y dx) along @p e.
+double greenArea(const BElem& e) noexcept;
+
+/// Signed contribution to the first moment about y=0, integral of y dA, along
+/// @p e (via -0.5*integral of y^2 dx, Green's theorem with P = -y^2/2).
+double greenMomentY(const BElem& e) noexcept;
+
+/// Physical arc length of @p e (always >= 0).
+double arcLength(const BElem& e) noexcept;
+
+// ===========================================================================
+// Height queries
+// ===========================================================================
+
+/**
+ * @brief x-coordinates where @p e crosses height @p y.
+ * @details A segment crosses at most once; an arc crosses at most twice
+ *          (within one sweep of magnitude <= 2*pi). A horizontal segment
+ *          (y0 == y1) never "crosses" — it either coincides with @p y or
+ *          misses it entirely, and is reported as 0 crossings either way.
+ * @param[out] xout up to 2 x-coordinates, ascending.
+ * @returns the crossing count, 0, 1, or 2.
+ * @note At a depth exactly equal to a vertex height shared by two elements,
+ *       both elements may independently report that shared crossing — the
+ *       critical-height analysis is what identifies those depths so the
+ *       Chebyshev compiler never has to evaluate exactly on one; evalExact()
+ *       is only exact for a generic (non-vertex) depth.
+ */
+int crossingsAt(const BElem& e, double y, double xout[2]) noexcept;
+
+/**
+ * @brief Clip @p e to the portion(s) at or below height @p y.
+ * @details For a segment this is at most one sub-segment. For an arc, the
+ *          region sin(theta) <= (y-cy)/r restricted to one sweep of
+ *          magnitude <= 2*pi is at most two disjoint sub-intervals (e.g. an
+ *          arc whose sweep passes over its own crown has one "below" piece on
+ *          each side of the peak) — hence `out[2]`. Each returned piece keeps
+ *          the SAME signed walking direction as @p e (so its own contribution
+ *          to greenArea/greenMomentY carries the correct sign).
+ * @returns the number of surviving pieces, 0, 1, or 2.
+ */
+int clipBelow(const BElem& e, double y, BElem out[2]) noexcept;
+
+// ===========================================================================
+// Whole-boundary evaluation
+// ===========================================================================
+
+/**
+ * @brief Exact section properties at depth @p y — no depth-quadrature.
+ * @details Clips every element to height <= y and sums Green contributions
+ *          for area and first moment; sums arc length of the surviving WALL
+ *          pieces only — a wall element lying exactly ON the y == level cut
+ *          is the free surface, not wetted perimeter, so it is excluded.
+ *          Top width is the sum of alternating spans of the sorted crossing
+ *          abscissae.
+ * @note Area and moment additionally need each wet span CLOSED at the free
+ *       surface: summing Green's-theorem contributions over the open wall
+ *       pieces alone is NOT the wetted area (a rectangle 10 ft wide clipped
+ *       at h=3 gives 15, not 30, from wall pieces alone — verified by hand).
+ *       A synthetic horizontal cap (right crossing -> left crossing, so the
+ *       whole contour stays CCW) closes each span for the Green's sum; its
+ *       own length is never added to `perim`.
+ * @note I1 requires NO integration over depth: I1(y) = A(y)*(y - ybar(y)).
+ *       This supersedes Simpson quadrature over depth for I1.
+ */
+ExactProps evalExact(const BElem* elems, int n, double y);
+
+// ===========================================================================
+// Construction
+// ===========================================================================
+
+/**
+ * @brief Build a closed all-straight boundary from a simple polygon.
+ * @details Convenience wrapper for fromArcSpec() with a null bulge array.
+ * @returns 0 (OK) or one of BoundaryError's TOO_FEW_POINTS / SELF_INTERSECTING
+ *          / ZERO_AREA / NON_FINITE.
+ */
+int fromPolyline(const double* x, const double* y, int n,
+                 std::vector<BElem>& out);
+
+/**
+ * @brief Build a closed boundary chain from points with optional DXF-style
+ *        arc bulges.
+ * @details Point i connects to point (i+1) mod n; `bulge[i]` (or 0.0 if
+ *          @p bulge is null) is the DXF-convention bulge `b = tan(theta/4)`
+ *          of that segment: `theta = 4*atan(b)` is the included angle (CCW
+ *          positive), `radius = chord / (2*|sin(theta/2)|)`, and the arc's
+ *          centre lies on the chord's perpendicular bisector at distance
+ *          `radius*cos(theta/2)`, on the LEFT of point_i -> point_{i+1} when
+ *          `b > 0` (and on the right when `b < 0`). `b == 0` is a straight
+ *          segment. `theta` is added, unreduced, to point i's own angle to
+ *          get point (i+1)'s angle — see the BElem note on why `a1 < a0` for
+ *          a negative-bulge (concave) arc is correct, not a bug.
+ *
+ *          Validates n >= 3, every coordinate and bulge finite, every
+ *          |bulge| <= 1, and that the chord chain (arcs approximated by
+ *          their chords, as the spec permits for this O(n^2) check) is
+ *          simple. Computes the total signed area; rejects a near-zero
+ *          result, and reverses the whole chain (point order AND bulge
+ *          signs, so the same physical arcs are kept) if the input traced
+ *          clockwise, so the output is always CCW. Finally shifts every
+ *          y-bearing field (y0, y1, and cy for arcs) so the boundary's own
+ *          minimum y — including any arc's interior low point, not just its
+ *          endpoints — lands at exactly 0.
+ * @returns 0 (OK) or one of BoundaryError's TOO_FEW_POINTS /
+ *          SELF_INTERSECTING / ZERO_AREA / NON_FINITE / BULGE_TOO_LARGE.
+ *          MALFORMED_CURVE_ROW (8) is never returned here — it belongs to
+ *          the [CURVES] text-row parser that produces these arrays.
+ */
+int fromArcSpec(const double* x, const double* y, const double* bulge, int n,
+                std::vector<BElem>& out);
+
+} // namespace openswmm::xsboundary
+
+#endif // OPENSWMM_XSECT_BOUNDARY_HPP

--- a/tests/unit/engine/CMakeLists.txt
+++ b/tests/unit/engine/CMakeLists.txt
@@ -174,6 +174,11 @@ if(OPENSWMM_FAST_XSECT_LOOKUP)
     target_compile_definitions(test_engine_xsect_kernels_parity
                                PRIVATE SWMM_XSECT_FAST_LOOKUP)
 endif()
+# Exact circular-arc/line boundary primitives (Green's theorem area/moment,
+# height queries, evalExact, and the polyline/bulge construction). Build-time
+# geometry compiler input for POLYGON sections — no FvGeometry/XsectEval
+# dependency, so it is a standalone target.
+add_gtest_unit(test_engine_xsect_boundary    test_xsect_boundary.cpp)
 # GUI editor round-trip getters/setters (pollutant units, aquifer ET pattern,
 # snowpack surfaces, inlet params/type, LID layers/type).
 add_gtest_unit(test_engine_editor_roundtrip_api test_editor_roundtrip_api.cpp)

--- a/tests/unit/engine/test_xsect_boundary.cpp
+++ b/tests/unit/engine/test_xsect_boundary.cpp
@@ -1,0 +1,294 @@
+/**
+ * @file test_xsect_boundary.cpp
+ * @brief Exact arc/line boundary primitives — Green's theorem area/moment,
+ *        height queries, evalExact, and construction (Phase 2 of the
+ *        cross-section geometry compiler).
+ *
+ * @details Every numeric target here was verified independently (200 001-pt
+ *          quadrature for the Green's-theorem formulas, hand-derived closed
+ *          forms for the rectangle and circle) before this file was written,
+ *          per the spec these primitives transcribe.
+ *
+ * @ingroup engine_hydraulics
+ */
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <limits>
+#include <vector>
+
+#include "hydraulics/XSectBoundary.hpp"
+
+using namespace openswmm::xsboundary;
+
+namespace {
+
+constexpr double kPi = 3.14159265358979323846;
+
+BElem makeArc(double cx, double cy, double r, double a0, double a1) {
+    BElem e{};
+    e.cx = cx; e.cy = cy; e.radius = r; e.a0 = a0; e.a1 = a1;
+    e.x0 = cx + r * std::cos(a0); e.y0 = cy + r * std::sin(a0);
+    e.x1 = cx + r * std::cos(a1); e.y1 = cy + r * std::sin(a1);
+    return e;
+}
+
+BElem makeSeg(double x0, double y0, double x1, double y1) {
+    BElem e{};
+    e.x0 = x0; e.y0 = y0; e.x1 = x1; e.y1 = y1;
+    return e;
+}
+
+/// Rectangle w x h, invert at y=0, CCW from (0,0).
+std::vector<BElem> rectangle(double w, double h) {
+    return {
+        makeSeg(0, 0, w, 0),
+        makeSeg(w, 0, w, h),
+        makeSeg(w, h, 0, h),
+        makeSeg(0, h, 0, 0),
+    };
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Green's theorem — area
+// ---------------------------------------------------------------------------
+
+TEST(XSectBoundary, GreenAreaFullCircle) {
+    // Full circle radius 2 centred (1,3): area = 4*pi, to 1e-14.
+    const BElem e = makeArc(1.0, 3.0, 2.0, 0.0, 2.0 * kPi);
+    EXPECT_NEAR(greenArea(e), 4.0 * kPi, 1.0e-14);
+}
+
+TEST(XSectBoundary, GreenAreaLowerHalfDisc) {
+    // Lower half-disc radius 2, centred at origin: area = 2*pi.
+    const BElem e = makeArc(0.0, 0.0, 2.0, kPi, 2.0 * kPi);
+    EXPECT_NEAR(greenArea(e), 2.0 * kPi, 1.0e-14);
+}
+
+TEST(XSectBoundary, GreenAreaSegmentMatchesShoelace) {
+    const BElem e = makeSeg(2.0, -1.0, 5.0, 3.0);
+    EXPECT_DOUBLE_EQ(greenArea(e), 0.5 * (2.0 * 3.0 - 5.0 * -1.0));
+}
+
+// ---------------------------------------------------------------------------
+// Green's theorem — first moment
+// ---------------------------------------------------------------------------
+
+TEST(XSectBoundary, GreenMomentYHalfDiscCentroid) {
+    // Lower half-disc radius r centred at origin: ybar = -4r/(3*pi).
+    const double r = 2.0;
+    const BElem e = makeArc(0.0, 0.0, r, kPi, 2.0 * kPi);
+    const double area = greenArea(e);
+    const double ybar = greenMomentY(e) / area;
+    EXPECT_NEAR(ybar, -4.0 * r / (3.0 * kPi), 1.0e-12);
+}
+
+TEST(XSectBoundary, GreenMomentYSegmentMatchesTrapezoid) {
+    const BElem e = makeSeg(0.0, 1.0, 4.0, 5.0);
+    const int m = 200001;
+    double ref = 0.0;
+    for (int i = 0; i < m; ++i) {
+        const double t0 = static_cast<double>(i) / m;
+        const double t1 = static_cast<double>(i + 1) / m;
+        const double y0 = e.y0 + t0 * (e.y1 - e.y0);
+        const double y1 = e.y0 + t1 * (e.y1 - e.y0);
+        // -0.5 * integral of y^2 dx, dx = (x1-x0)/m per step.
+        const double dx = (e.x1 - e.x0) / m;
+        ref += -0.5 * dx * 0.5 * (y0 * y0 + y1 * y1);
+    }
+    EXPECT_NEAR(greenMomentY(e), ref, 1.0e-9 * std::fabs(ref));
+}
+
+// ---------------------------------------------------------------------------
+// Rectangle — exact at several depths
+// ---------------------------------------------------------------------------
+
+TEST(XSectBoundary, RectangleExactPropertiesAtSeveralDepths) {
+    // i stops short of 20 (y == h exactly) on purpose: at the flat rim,
+    // crossingsAt's half-open convention reports no crossing on a HORIZONTAL
+    // top edge (only a transversal wall crossing counts), so width would
+    // read 0 instead of w there. That degenerate exact-rim height is exactly
+    // what the critical-height analysis (Phase 3) exists to enumerate and
+    // special-case; evalExact() is only claimed exact at a generic depth.
+    const double w = 3.0, h = 5.0;
+    const auto rect = rectangle(w, h);
+    for (int i = 1; i <= 19; ++i) {
+        const double y = h * static_cast<double>(i) / 20.0;
+        const ExactProps p = evalExact(rect.data(), static_cast<int>(rect.size()), y);
+        EXPECT_NEAR(p.area, w * y, 1.0e-13) << "at y=" << y;
+        EXPECT_NEAR(p.width, w, 1.0e-13) << "at y=" << y;
+        EXPECT_NEAR(p.perim, 2.0 * y + w, 1.0e-13) << "at y=" << y;
+        EXPECT_NEAR(p.i1, w * y * y / 2.0, 1.0e-12) << "at y=" << y;
+        EXPECT_EQ(p.ncomp, 1);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Arc vs polyline — a circle built one way should crush a circle built the
+// coarse way.
+// ---------------------------------------------------------------------------
+
+TEST(XSectBoundary, ArcCircleMatchesAnalyticExactlyPolylineDoesNot) {
+    const double r = 2.0, d = 2.0 * r;
+    const BElem arc = makeArc(0.0, r, r, -0.5 * kPi, 1.5 * kPi);
+    std::vector<BElem> chain = {arc};
+
+    const double y = 0.5 * d;   // half-full: exact A = pi*r^2/2
+    const ExactProps pa = evalExact(chain.data(), 1, y);
+    const double analytic = 0.5 * kPi * r * r;
+    EXPECT_NEAR(pa.area, analytic, 1.0e-13);
+
+    // A 512-vertex polyline approximation of the same circle should show a
+    // measurable (not 1e-13-level) discretization error.
+    constexpr int nseg = 512;
+    std::vector<double> px(nseg), py(nseg);
+    for (int i = 0; i < nseg; ++i) {
+        const double t = 2.0 * kPi * static_cast<double>(i) / nseg;
+        px[i] = r * std::cos(t);
+        py[i] = r + r * std::sin(t);
+    }
+    std::vector<BElem> poly;
+    ASSERT_EQ(fromPolyline(px.data(), py.data(), nseg, poly), 0);
+    const ExactProps pp = evalExact(poly.data(), static_cast<int>(poly.size()), y);
+    const double poly_err = std::fabs(pp.area - analytic) / analytic;
+    EXPECT_GT(poly_err, 1.0e-7);
+    EXPECT_LT(poly_err, 1.0e-3);
+}
+
+// ---------------------------------------------------------------------------
+// fromArcSpec — bulge construction
+// ---------------------------------------------------------------------------
+
+TEST(XSectBoundary, FourQuarterArcBulgesFormAFullCircle) {
+    // Four points on a unit circle at 0, 90, 180, 270 degrees, each segment
+    // bulging by tan(pi/8) (a 90-degree arc) traces the full circle CCW.
+    const double b = std::tan(0.25 * kPi / 2.0);   // tan(theta/4), theta = pi/2
+    const double x[4] = {1.0, 0.0, -1.0, 0.0};
+    const double y[4] = {0.0, 1.0, 0.0, -1.0};
+    const double bulge[4] = {b, b, b, b};
+
+    std::vector<BElem> chain;
+    ASSERT_EQ(fromArcSpec(x, y, bulge, 4, chain), 0);
+    ASSERT_EQ(chain.size(), 4u);
+
+    // Invert shifted to y=0: original min y was -1, so full depth is 2.
+    const double y_full = 2.0;
+    const ExactProps full = evalExact(chain.data(), 4, y_full);
+    EXPECT_NEAR(full.area, kPi, 1.0e-10);
+    EXPECT_NEAR(full.width, 0.0, 1.0e-9);   // top of circle: width -> 0
+
+    // A GENERIC depth (not the y=1.0 equator, which after the shift lands
+    // exactly on two of the four vertex heights at once — a critical-height
+    // case that crossingsAt's half-open convention does not claim to handle;
+    // that degeneracy is Phase 3's job). At y=1.3 the circle (centre (0,1),
+    // r=1) has local height d=0.3 above its own centre; width and area below
+    // it follow the standard circular-segment closed forms.
+    const double d = 0.3;
+    const ExactProps generic = evalExact(chain.data(), 4, 1.0 + d);
+    const double width_ref = 2.0 * std::sqrt(1.0 - d * d);
+    const double area_ref  = d * std::sqrt(1.0 - d * d) + std::asin(d) + 0.5 * kPi;
+    EXPECT_NEAR(generic.width, width_ref, 1.0e-10);
+    EXPECT_NEAR(generic.area, area_ref, 1.0e-10);
+}
+
+TEST(XSectBoundary, NegativeBulgeConcaveNotchStillGivesCorrectArea) {
+    // A square with one edge replaced by a small CONCAVE (inward, negative
+    // bulge) notch. The enclosed area must be the square's area minus the
+    // notch's bulge area — this is the case that requires a1 < a0.
+    const double s = 4.0;
+    // Points CCW: (0,0) -> (4,0) [concave notch] -> (4,4) -> (0,4) -> close.
+    const double x[4] = {0.0, 4.0, 4.0, 0.0};
+    const double y[4] = {0.0, 0.0, 4.0, 4.0};
+    const double b = -0.4142135623730951;   // tan(45deg/4)*(-1)-ish, |b|<1
+    const double bulge[4] = {b, 0.0, 0.0, 0.0};
+
+    std::vector<BElem> chain;
+    ASSERT_EQ(fromArcSpec(x, y, bulge, 4, chain), 0);
+    ASSERT_EQ(chain[0].radius > 0.0, true);
+    EXPECT_LT(chain[0].a1, chain[0].a0) << "concave (negative-bulge) arc must have a1 < a0";
+
+    const double theta = 4.0 * std::atan(b);   // negative
+    const double c = 4.0;                      // chord length
+    const double r = c / (2.0 * std::fabs(std::sin(0.5 * theta)));
+    // Circular-segment area cut OUT by the notch (theta magnitude, minor segment).
+    const double notch_area = 0.5 * r * r * (std::fabs(theta) - std::sin(std::fabs(theta)));
+
+    const ExactProps full = evalExact(chain.data(), 4, s);
+    EXPECT_NEAR(full.area, s * s - notch_area, 1.0e-9);
+}
+
+// ---------------------------------------------------------------------------
+// Validation / error codes
+// ---------------------------------------------------------------------------
+
+TEST(XSectBoundary, RejectsTooFewPoints) {
+    const double x[2] = {0, 1};
+    const double y[2] = {0, 1};
+    std::vector<BElem> out;
+    EXPECT_EQ(fromPolyline(x, y, 2, out), 1);
+}
+
+TEST(XSectBoundary, RejectsSelfIntersectingBowtie) {
+    // Bow-tie: (0,0) -> (4,4) -> (4,0) -> (0,4) -> close. Chords (0,0)-(4,4)
+    // and (4,0)-(0,4) cross.
+    const double x[4] = {0, 4, 4, 0};
+    const double y[4] = {0, 4, 0, 4};
+    std::vector<BElem> out;
+    EXPECT_EQ(fromPolyline(x, y, 4, out), 2);
+}
+
+TEST(XSectBoundary, RejectsZeroArea) {
+    // All points collinear.
+    const double x[3] = {0, 1, 2};
+    const double y[3] = {0, 0, 0};
+    std::vector<BElem> out;
+    EXPECT_EQ(fromPolyline(x, y, 3, out), 3);
+}
+
+TEST(XSectBoundary, RejectsNonFinite) {
+    const double x[3] = {0, 1, std::numeric_limits<double>::quiet_NaN()};
+    const double y[3] = {0, 1, 2};
+    std::vector<BElem> out;
+    EXPECT_EQ(fromPolyline(x, y, 3, out), 4);
+}
+
+TEST(XSectBoundary, RejectsBulgeMagnitudeAboveOne) {
+    const double x[3] = {0, 1, 2};
+    const double y[3] = {0, 1, 0};
+    const double bulge[3] = {1.5, 0, 0};
+    std::vector<BElem> out;
+    EXPECT_EQ(fromArcSpec(x, y, bulge, 3, out), 7);
+}
+
+TEST(XSectBoundary, ClockwiseInputIsReorientedCCW) {
+    // Same rectangle as `rectangle()` but wound CW.
+    const double x[4] = {0, 0, 3, 3};
+    const double y[4] = {0, 5, 5, 0};
+    std::vector<BElem> out;
+    ASSERT_EQ(fromPolyline(x, y, 4, out), 0);
+    double area = 0.0;
+    for (const BElem& e : out) area += greenArea(e);
+    EXPECT_GT(area, 0.0);
+    EXPECT_NEAR(area, 15.0, 1.0e-12);
+}
+
+TEST(XSectBoundary, ShiftsMinYToZeroIncludingArcInterior) {
+    // A small triangle up high, (-1,5)-(1,5)-(0,6), with the base replaced by
+    // a semicircle bulge (b=1) that dips DOWN to y=4 at its midpoint — below
+    // every one of the three VERTEX y-values (5, 5, 6). The boundary's true
+    // min y must come from that arc interior, not from min(y0,y1,y2).
+    const double x[3] = {-1.0, 1.0, 0.0};
+    const double y[3] = {5.0, 5.0, 6.0};
+    const double bulge[3] = {1.0, 0.0, 0.0};
+    std::vector<BElem> out;
+    ASSERT_EQ(fromArcSpec(x, y, bulge, 3, out), 0);
+    double y_min = std::numeric_limits<double>::infinity();
+    for (const BElem& e : out) {
+        y_min = std::min({y_min, e.y0, e.y1});
+        if (e.radius != 0.0) y_min = std::min(y_min, e.cy - e.radius);
+    }
+    EXPECT_NEAR(y_min, 0.0, 1.0e-12);
+}


### PR DESCRIPTION
Adds XSectBoundary: describes a cross-section as a closed chain of straight lines and true circular arcs, and computes area, wetted perimeter, top width, and the hydrostatic moment exactly from it — no tables, no discretization error, no depth quadrature.

Build-time only (runs when a section is compiled, not in the solver loop) and wired into nothing yet, so nothing existing changes.

Two correctness points worth a look during review: concave arcs legitimately have a1 < a0, and the area sum needs a synthetic horizontal cap to close each wet span. Both are derived and covered by tests.

16 tests: Green's-theorem formulas vs analytic/quadrature references, a rectangle exact at 19 depths, arcs vs a 512-vertex polyline, both bulge signs, all 5 validation error codes.