### PR TITLE
feat(hydraulics): critical heights and Puiseux map exponents

### DIFF
--- a/src/engine/hydraulics/XSectBoundary.cpp
+++ b/src/engine/hydraulics/XSectBoundary.cpp
@@ -75,24 +75,35 @@ int arcCrossingAngles(const BElem& e, double y, double theta_out[2]) noexcept {
     return count;
 }
 
+/// True when some angle congruent to @p base (mod 2*pi) lies within the arc's
+/// sweep. Shared by elemMinY/elemMaxY and the tangency scan in
+/// findCriticalHeights, and using the same k-range convention as
+/// arcCrossingAngles so all four agree about what "within the sweep" means.
+bool sweepHits(const BElem& e, double base) noexcept {
+    const double lo = std::min(e.a0, e.a1);
+    const double hi = std::max(e.a0, e.a1);
+    const double kmin = std::ceil((lo - base) / kTwoPi - 1.0e-12);
+    const double kmax = std::floor((hi - base) / kTwoPi + 1.0e-12);
+    return kmin <= kmax;
+}
+
 /// True minimum y over the whole element, including an arc's interior low
 /// point (theta == -pi/2 mod 2*pi) when that angle falls within its sweep —
 /// not just its two endpoints.
 double elemMinY(const BElem& e) noexcept {
     if (e.radius == 0.0) return std::min(e.y0, e.y1);
-    double m = std::min(e.y0, e.y1);
-    const double lo = std::min(e.a0, e.a1);
-    const double hi = std::max(e.a0, e.a1);
-    const double base = -0.5 * M_PI;
-    const auto kmin = static_cast<long>(std::floor((lo - base) / kTwoPi)) - 1;
-    const auto kmax = static_cast<long>(std::ceil((hi - base) / kTwoPi)) + 1;
-    for (long k = kmin; k <= kmax; ++k) {
-        const double theta = base + static_cast<double>(k) * kTwoPi;
-        if (theta >= lo - 1.0e-12 && theta <= hi + 1.0e-12) {
-            m = std::min(m, e.cy - e.radius);
-        }
-    }
-    return m;
+    const double m = std::min(e.y0, e.y1);
+    return sweepHits(e, -0.5 * M_PI) ? std::min(m, e.cy - e.radius) : m;
+}
+
+/// True maximum y over the whole element — the mirror of elemMinY, counting an
+/// arc's interior high point (theta == +pi/2 mod 2*pi) only when the sweep
+/// actually reaches it. A pointed arch, whose arcs stop short of their own
+/// crowns, must report its apex height rather than cy + r.
+double elemMaxY(const BElem& e) noexcept {
+    if (e.radius == 0.0) return std::max(e.y0, e.y1);
+    const double m = std::max(e.y0, e.y1);
+    return sweepHits(e, 0.5 * M_PI) ? std::max(m, e.cy + e.radius) : m;
 }
 
 int orientation(double ax, double ay, double bx, double by,
@@ -331,6 +342,97 @@ ExactProps evalExact(const BElem* elems, int n, double y) {
     out.i1    = area * (y - out.ybar);
     out.ncomp = static_cast<int>(xs.size() / 2);
     return out;
+}
+
+// ===========================================================================
+// Critical heights
+// ===========================================================================
+
+void findCriticalHeights(const BElem* elems, int n,
+                         std::vector<CriticalHeight>& out) {
+    out.clear();
+    if (n <= 0) return;
+
+    double y_full = 0.0;
+    for (int i = 0; i < n; ++i) y_full = std::max(y_full, elemMaxY(elems[i]));
+    if (!(y_full > 0.0)) return;
+
+    // Clamp rather than discard: a tangency computed as cy - r can land an ulp
+    // below 0 (or cy + r an ulp above y_full) after the invert shift, and
+    // dropping it would silently lose the 1.5 tag on a round invert or crown —
+    // exactly the tag that matters most.
+    auto clampY = [y_full](double y) { return std::clamp(y, 0.0, y_full); };
+
+    // Source 1 — element endpoints: corners, tangential joints, and the ends
+    // of horizontal segments. Plus both domain ends, unconditionally.
+    std::vector<double> endpoints;
+    endpoints.reserve(static_cast<std::size_t>(2 * n + 2));
+    for (int i = 0; i < n; ++i) {
+        endpoints.push_back(clampY(elems[i].y0));
+        endpoints.push_back(clampY(elems[i].y1));
+    }
+    endpoints.push_back(0.0);
+    endpoints.push_back(y_full);
+
+    std::vector<CriticalHeight> claims;
+    claims.reserve(endpoints.size() + static_cast<std::size_t>(2 * n));
+    for (const double y : endpoints) claims.push_back(CriticalHeight{y, 1.0, 1.0});
+
+    // Source 2 — arc horizontal tangencies, the ONLY source of a 1.5 tag. An
+    // arc lies ABOVE its own lowest point and BELOW its own highest one, so
+    // that is the side the half-power lands on. This holds whether the
+    // tangency is interior to the sweep or sits at one of its ends, which is
+    // why no interior/endpoint distinction is needed.
+    const double snap = 1.0e-9 * y_full;
+    for (int i = 0; i < n; ++i) {
+        const BElem& e = elems[i];
+        if (e.radius == 0.0) continue;
+        for (int top = 0; top < 2; ++top) {
+            const double base = (top != 0) ? 0.5 * M_PI : -0.5 * M_PI;
+            if (!sweepHits(e, base)) continue;
+
+            double y_t = clampY((top != 0) ? (e.cy + e.radius)
+                                           : (e.cy - e.radius));
+            // Snap onto the NEAREST endpoint within range instead of leaving a
+            // sub-1e-9 sliver piece behind it (see the @note on
+            // findCriticalHeights). Nearest rather than first-found so the
+            // result cannot depend on element ordering.
+            const double y_raw = y_t;
+            double best = snap;
+            for (const double ye : endpoints) {
+                const double d = std::fabs(ye - y_raw);
+                if (d <= best) { best = d; y_t = ye; }
+            }
+
+            CriticalHeight c{y_t, 1.0, 1.0};
+            if (top != 0) c.exp_below = 1.5;
+            else          c.exp_above = 1.5;
+            claims.push_back(c);
+        }
+    }
+
+    std::sort(claims.begin(), claims.end(),
+              [](const CriticalHeight& a, const CriticalHeight& b) {
+                  return a.y < b.y;
+              });
+
+    // Dedupe, unioning the tags by MAX so a 1.5 claim from any contributing
+    // feature survives the merge. This is also what makes three-or-more
+    // simultaneous component merges need no special case.
+    const double tol = 1.0e-12 * y_full;
+    for (const CriticalHeight& c : claims) {
+        if (!out.empty() && c.y - out.back().y <= tol) {
+            out.back().exp_above = std::max(out.back().exp_above, c.exp_above);
+            out.back().exp_below = std::max(out.back().exp_below, c.exp_below);
+            continue;
+        }
+        out.push_back(c);
+    }
+
+    // Pin the domain ends exactly — downstream piece construction indexes off
+    // these two values, so they must be 0 and y_full to the bit.
+    out.front().y = 0.0;
+    out.back().y  = y_full;
 }
 
 // ===========================================================================

--- a/src/engine/hydraulics/XSectBoundary.hpp
+++ b/src/engine/hydraulics/XSectBoundary.hpp
@@ -168,6 +168,150 @@ int clipBelow(const BElem& e, double y, BElem out[2]) noexcept;
 ExactProps evalExact(const BElem* elems, int n, double y);
 
 // ===========================================================================
+// Critical heights (Morse / Newton-Puiseux analysis)
+// ===========================================================================
+
+/**
+ * @brief One height at which A(y), B(y) or P(y) loses smoothness, tagged with
+ *        the coordinate-map exponent on each side.
+ * @details A piece `[y_i, y_{i+1}]` of the compiled section takes `exp_lo` from
+ *          `crit[i].exp_above` and `exp_hi` from `crit[i+1].exp_below`.
+ *
+ * **What `exp_above`/`exp_below` actually encode — read this before using
+ * them as if they were leading exponents.** The value is a *map selector*: it
+ * answers "is A analytic on this side, or does it carry a half-integer branch
+ * point?", NOT "what is the leading power of A here". Only two values are
+ * emitted:
+ *
+ *   - `1.0` — A is ANALYTIC on that side; the Chebyshev fit needs no
+ *     coordinate change (identity map).
+ *   - `1.5` — A ~ |Δy|^{3/2}; a square-root branch point, so the piece needs
+ *     the stretch that makes A analytic in the mapped variable.
+ *
+ * The two-value encoding is deliberately coarser than a true Puiseux exponent,
+ * and the spec's 1.0/1.5 dichotomy is genuinely incomplete — reported here as
+ * the design document asks rather than silently forced:
+ *
+ *   - A **V-notch invert** (two straight segments meeting at a point) has
+ *     A = z·y², a true leading exponent of **2.0**, not 1.0.
+ *   - A **pointed / gothic crown** likewise has A_full − A ~ δ².
+ *
+ * Both are nevertheless tagged `1.0`, and that is the CORRECT action, because
+ * every integer exponent is analytic and therefore wants the identity map. Only
+ * the half-integer case needs a different coordinate. Tagging by "analytic vs.
+ * √-branch" is what the map table is really keyed on; recording 2.0 would add
+ * information no consumer can use and would fall outside the table's rows.
+ *
+ * @warning The design document's blanket claim that "a closed conduit's crown
+ *          has exp_below = 1.5; its invert has exp_above = 1.5" holds only for
+ *          a SMOOTH (horizontally tangent) crown/invert. A pointed crown
+ *          (GOTHIC) and a V-notch or flat invert are analytic and get 1.0.
+ *          This function computes the tag rather than assuming it.
+ */
+struct CriticalHeight {
+    double y         = 0.0;  ///< height above the invert (ft)
+    double exp_above = 1.0;  ///< map selector for A just ABOVE this height
+    double exp_below = 1.0;  ///< map selector for A just BELOW this height
+};
+
+/**
+ * @brief Locate every height at which A(y), B(y) or P(y) loses smoothness.
+ *
+ * @details This is the Morse / Newton-Puiseux step: it is what lets the
+ *          spectral fit downstream converge geometrically instead of
+ *          algebraically. Splitting the depth range at these heights leaves A
+ *          analytic on the interior of every piece; the exponent tags then say
+ *          which pieces additionally need a coordinate change at their ends.
+ *
+ *          Two sources are enumerated, and together they are exhaustive:
+ *
+ *          1. **Every element endpoint height** (`y0`, `y1` of each element).
+ *             This covers corners, tangential joints, and the ends of
+ *             horizontal segments — every place where the boundary's own
+ *             parameterisation changes.
+ *          2. **Every arc horizontal tangency** — angles congruent to ±π/2
+ *             within the arc's sweep, i.e. the arc's own lowest (`cy − r`) and
+ *             highest (`cy + r`) points.
+ *
+ *          `0` and `y_full` are always included. Heights are returned sorted
+ *          ascending and deduplicated to `1e-12 · y_full`; where duplicates
+ *          merge, the exponent tags are unioned by MAX, so a `1.5` claim from
+ *          any contributing feature survives.
+ *
+ *          **The tagging rule reduces to one sentence:** a `1.5` tag arises
+ *          only from a smooth horizontal tangency, and it lands on the side of
+ *          that height where the tangent arc actually lies — above its lowest
+ *          point, below its highest point. Everything else is `1.0`.
+ *
+ *          That single rule is what makes this robust. A tangency is where two
+ *          boundary crossings are born or annihilate (a fold), and a fold is
+ *          the only way a crossing abscissa can pick up a √|Δy| term, which is
+ *          in turn the only way A acquires a half-integer power. A corner —
+ *          however sharp, and whichever direction it points — never produces
+ *          one: each incident element contributes an abscissa that is analytic
+ *          on its own side of the joint, so A is analytic on each side too.
+ *          The function therefore never has to classify "corner vs. smooth
+ *          joint", which would be the fragile part.
+ *
+ * @param elems boundary chain, closed and CCW, with `min(y) == 0` — i.e. as
+ *              produced by fromPolyline()/fromArcSpec(). Heights are reported
+ *              in that shifted frame.
+ * @param n     element count.
+ * @param[out] out sorted, deduplicated critical heights. Cleared on entry;
+ *              left empty if @p n <= 0 or the chain has zero height.
+ *
+ * @note **Cases the design document leaves open, and what is done about each.**
+ *
+ *       - *Two arcs meeting tangentially (non-horizontal tangent) — corner or
+ *         smooth point?* Operationally neither. It IS a critical height and
+ *         must be split at: the curvature jumps, so A is C¹ but not C², and a
+ *         Chebyshev fit spanning it converges only algebraically. But the tag
+ *         is `1.0` on both sides, because A is analytic on each side
+ *         separately with nonzero slope. `1.0` means "analytic, identity map",
+ *         NOT "corner" — the split and the tag are independent decisions.
+ *
+ *       - *An exactly horizontal segment.* Critical, `1.0`/`1.0`. The design
+ *         document's "infinite dA/dy over a finite span" is imprecise:
+ *         dA/dy = B does not blow up, it JUMPS by the segment's width, so A
+ *         stays continuous with a slope kink and is analytic on each side.
+ *         Identity map both sides is right, and reproducing that jump exactly
+ *         is what makes a bench's top-width discontinuity come out correct.
+ *
+ *       - *An arc extremum within `1e-9 · y_full` of an element endpoint.* The
+ *         tangency height is SNAPPED onto the endpoint and the two exponent
+ *         claims are unioned (so `1.5` survives). This deliberately overrides
+ *         the general `1e-12` dedupe for this one pairing. Rationale: a piece
+ *         narrower than `1e-9 · y_full` carries no resolvable information, its
+ *         Chebyshev fit is numerically meaningless, and it burns one of the 24
+ *         piece slots — whereas the merged height with the stronger tag
+ *         describes the local behaviour correctly.
+ *
+ *       - *A cusp where two arcs meet with opposite curvature.* If the shared
+ *         tangent is HORIZONTAL, each arc contributes a half-power on its own
+ *         side and the height is tagged `1.5`/`1.5` — this is exactly the
+ *         two-sided map case, and it falls out of the tagging rule with no
+ *         special handling (the arc below claims `exp_below`, the arc above
+ *         claims `exp_above`). If the shared tangent is NOT horizontal, the
+ *         enclosed spike has width O(δ²), which is analytic, so `1.0`/`1.0`.
+ *
+ *       - *Three or more components merging at the same height.* One critical
+ *         height is emitted; the claims union by MAX. Each merge contributes
+ *         the same leading power, so the tag is unaffected by how many coincide
+ *         — only the component count changes, and that is evalExact()'s
+ *         business, not the exponent's. No special case is needed.
+ *
+ * @note Merge and split heights need no separate search pass. A merge requires
+ *       two crossings to collide, which requires either a smooth horizontal
+ *       tangency (source 2) or a vertex that is a local extremum of height
+ *       (source 1). Both are already enumerated, so scanning for component
+ *       merges independently would only rediscover heights already found.
+ *
+ * @see evalExact
+ */
+void findCriticalHeights(const BElem* elems, int n,
+                         std::vector<CriticalHeight>& out);
+
+// ===========================================================================
 // Construction
 // ===========================================================================
 

--- a/tests/unit/engine/test_xsect_boundary.cpp
+++ b/tests/unit/engine/test_xsect_boundary.cpp
@@ -275,6 +275,191 @@ TEST(XSectBoundary, ClockwiseInputIsReorientedCCW) {
     EXPECT_NEAR(area, 15.0, 1.0e-12);
 }
 
+// ---------------------------------------------------------------------------
+// Critical heights + Puiseux/map exponents (Phase 3)
+// ---------------------------------------------------------------------------
+//
+// The tag is a MAP SELECTOR, not a faithful leading exponent: 1.5 means "A has
+// a sqrt branch point here, stretch the coordinate", 1.0 means "A is analytic,
+// use the identity". Several tests below pin cases where the true leading
+// exponent is 2.0 but 1.0 is nevertheless the right tag.
+
+namespace {
+
+const CriticalHeight* critAt(const std::vector<CriticalHeight>& v, double y,
+                             double tol = 1.0e-9) {
+    for (const CriticalHeight& c : v) {
+        if (std::fabs(c.y - y) <= tol) return &c;
+    }
+    return nullptr;
+}
+
+} // namespace
+
+TEST(XSectBoundary, CriticalHeightsAreSortedUniqueAndSpanTheDomain) {
+    const auto rect = rectangle(3.0, 5.0);
+    std::vector<CriticalHeight> crit;
+    findCriticalHeights(rect.data(), static_cast<int>(rect.size()), crit);
+
+    ASSERT_GE(crit.size(), 2u);
+    EXPECT_DOUBLE_EQ(crit.front().y, 0.0);
+    EXPECT_DOUBLE_EQ(crit.back().y, 5.0);
+    for (std::size_t i = 1; i < crit.size(); ++i) {
+        EXPECT_GT(crit[i].y, crit[i - 1].y) << "not strictly sorted at " << i;
+    }
+}
+
+TEST(XSectBoundary, CircularPipeGetsFifteenAtBothInvertAndCrown) {
+    // The case the two-sided coordinate map exists for: a smooth round invert
+    // AND a smooth round crown, so the piece spanning them is 1.5 at both ends.
+    const double r = 1.5;
+    const std::vector<BElem> circle = {makeArc(0.0, r, r, -0.5 * kPi, 1.5 * kPi)};
+    std::vector<CriticalHeight> crit;
+    findCriticalHeights(circle.data(), 1, crit);
+
+    ASSERT_EQ(crit.size(), 2u);
+    EXPECT_DOUBLE_EQ(crit[0].y, 0.0);
+    EXPECT_DOUBLE_EQ(crit[1].y, 2.0 * r);
+    EXPECT_DOUBLE_EQ(crit[0].exp_above, 1.5) << "smooth round invert";
+    EXPECT_DOUBLE_EQ(crit[1].exp_below, 1.5) << "smooth round crown";
+}
+
+TEST(XSectBoundary, RectangleIsAnalyticEverywhere) {
+    const auto rect = rectangle(3.0, 5.0);
+    std::vector<CriticalHeight> crit;
+    findCriticalHeights(rect.data(), static_cast<int>(rect.size()), crit);
+
+    ASSERT_EQ(crit.size(), 2u);
+    for (const CriticalHeight& c : crit) {
+        EXPECT_DOUBLE_EQ(c.exp_above, 1.0);
+        EXPECT_DOUBLE_EQ(c.exp_below, 1.0);
+    }
+}
+
+TEST(XSectBoundary, VNotchInvertIsTaggedAnalyticDespiteTrueExponentTwo) {
+    // A triangular invert has A = z*y^2 — a TRUE Puiseux exponent of 2.0, which
+    // the 1.0/1.5 dichotomy cannot express. 1.0 is still the correct tag,
+    // because the map only asks "analytic or sqrt-branch?" and y^2 is analytic.
+    // If this ever reads 1.5 the compiler would stretch a polynomial and lose
+    // its exactness.
+    const double x[3] = {0.0, 2.0, -2.0};
+    const double y[3] = {0.0, 3.0, 3.0};
+    std::vector<BElem> tri;
+    ASSERT_EQ(fromPolyline(x, y, 3, tri), 0);
+
+    std::vector<CriticalHeight> crit;
+    findCriticalHeights(tri.data(), static_cast<int>(tri.size()), crit);
+    ASSERT_EQ(crit.size(), 2u);
+    EXPECT_DOUBLE_EQ(crit[0].y, 0.0);
+    EXPECT_DOUBLE_EQ(crit[0].exp_above, 1.0) << "V-notch invert is analytic";
+}
+
+TEST(XSectBoundary, PointedArchCrownIsAnalyticNotFifteen) {
+    // Corrects the design document's blanket "a closed conduit's crown has
+    // exp_below = 1.5". A GOTHIC-style pointed arch is two arcs meeting at a
+    // CORNER: neither arc reaches its own horizontal tangent, the crown width
+    // closes linearly, A_full - A ~ delta^2, and the crown is analytic.
+    // Tagging it 1.5 would stretch a coordinate around a non-existent branch
+    // point and degrade the fit.
+    const double a = 1.0, R = 2.0;
+    const double apex = std::sqrt(3.0) * a;
+    const std::vector<BElem> arch = {
+        makeSeg(-a, 0.0, a, 0.0),
+        makeArc(-a, 0.0, R, 0.0, kPi / 3.0),          // springing -> apex
+        makeArc(a, 0.0, R, 2.0 * kPi / 3.0, kPi),     // apex -> springing
+    };
+    std::vector<CriticalHeight> crit;
+    findCriticalHeights(arch.data(), static_cast<int>(arch.size()), crit);
+
+    ASSERT_EQ(crit.size(), 2u);
+    EXPECT_NEAR(crit.back().y, apex, 1.0e-12) << "y_full must be the apex, not cy+r";
+    EXPECT_DOUBLE_EQ(crit.back().exp_below, 1.0) << "pointed crown is analytic";
+}
+
+TEST(XSectBoundary, RoundInvertUnderABoxSplitsAtTheSpringingLine) {
+    // Round low-flow invert joined to vertical walls: 1.5 at the invert, and a
+    // plain analytic split where the arc meets the walls (curvature jumps, so
+    // it must still be a piece boundary even though the tag is 1.0).
+    const double r = 1.0, H = 4.0;
+    const std::vector<BElem> sect = {
+        makeArc(0.0, r, r, kPi, 2.0 * kPi),
+        makeSeg(r, r, r, H),
+        makeSeg(r, H, -r, H),
+        makeSeg(-r, H, -r, r),
+    };
+    std::vector<CriticalHeight> crit;
+    findCriticalHeights(sect.data(), static_cast<int>(sect.size()), crit);
+
+    ASSERT_EQ(crit.size(), 3u);
+    EXPECT_DOUBLE_EQ(crit[0].y, 0.0);
+    EXPECT_DOUBLE_EQ(crit[0].exp_above, 1.5) << "smooth round invert";
+    EXPECT_NEAR(crit[1].y, r, 1.0e-12) << "springing line must be a critical height";
+    EXPECT_DOUBLE_EQ(crit[1].exp_above, 1.0);
+    EXPECT_DOUBLE_EQ(crit[1].exp_below, 1.0);
+    EXPECT_DOUBLE_EQ(crit[2].y, H);
+}
+
+TEST(XSectBoundary, HorizontalBenchIsACriticalHeightAndStaysAnalytic) {
+    // A bench makes the TOP WIDTH jump discontinuously, but A only gains a
+    // slope kink and stays analytic on each side — so it must be split at, yet
+    // tagged 1.0/1.0. (dA/dy does not blow up here; it steps by the bench
+    // width.)
+    const double w1 = 1.0, w2 = 3.0, h1 = 2.0, h2 = 5.0;
+    const double x[8] = {-w1, w1, w1, w2, w2, -w2, -w2, -w1};
+    const double y[8] = {0.0, 0.0, h1, h1, h2, h2, h1, h1};
+    std::vector<BElem> sect;
+    ASSERT_EQ(fromPolyline(x, y, 8, sect), 0);
+
+    std::vector<CriticalHeight> crit;
+    findCriticalHeights(sect.data(), static_cast<int>(sect.size()), crit);
+
+    const CriticalHeight* bench = critAt(crit, h1);
+    ASSERT_NE(bench, nullptr) << "bench height was not reported as critical";
+    EXPECT_DOUBLE_EQ(bench->exp_above, 1.0);
+    EXPECT_DOUBLE_EQ(bench->exp_below, 1.0);
+}
+
+TEST(XSectBoundary, OppositeCurvatureHorizontalTangencyIsFifteenOnBothSides) {
+    // Two arcs meeting with a shared HORIZONTAL tangent and opposite curvature.
+    // Height is monotone through the joint (no local extremum), but the
+    // crossing abscissa picks up a sqrt on BOTH sides, so A is non-analytic
+    // above and below. Falls out of the tagging rule with no special case: the
+    // lower arc claims exp_below from its top, the upper claims exp_above from
+    // its bottom.
+    //
+    // An OPEN two-element chain on purpose — this isolates the exponent rule
+    // from any closed-boundary bookkeeping.
+    const std::vector<BElem> s_curve = {
+        makeArc(0.0, 0.0, 1.0, 0.25 * kPi, 0.5 * kPi),    // ends at ITS top, y=1
+        makeArc(0.0, 2.0, 1.0, -0.5 * kPi, -0.25 * kPi),  // starts at ITS bottom, y=1
+    };
+    std::vector<CriticalHeight> crit;
+    findCriticalHeights(s_curve.data(), 2, crit);
+
+    const CriticalHeight* joint = critAt(crit, 1.0);
+    ASSERT_NE(joint, nullptr);
+    EXPECT_DOUBLE_EQ(joint->exp_above, 1.5);
+    EXPECT_DOUBLE_EQ(joint->exp_below, 1.5);
+}
+
+TEST(XSectBoundary, TangencyWithinSnapDistanceOfAnEndpointMergesKeepingFifteen) {
+    // An arc extremum a hair off an element endpoint must NOT leave a sliver
+    // piece behind it; it snaps onto the endpoint and the 1.5 claim survives
+    // the merge. Without the snap this reports three criticals (0, d, y_full)
+    // with a piece of width 5e-10.
+    const double d = 5.0e-10;
+    const std::vector<BElem> chain = {
+        makeArc(0.0, 1.0 + d, 1.0, kPi, 2.0 * kPi),   // bottom tangency at y = d
+        makeSeg(0.0, 0.0, 1.0, 0.0),                  // endpoint at y = 0
+    };
+    std::vector<CriticalHeight> crit;
+    findCriticalHeights(chain.data(), 2, crit);
+
+    ASSERT_EQ(crit.size(), 2u) << "tangency did not snap onto the endpoint";
+    EXPECT_DOUBLE_EQ(crit[0].y, 0.0);
+    EXPECT_DOUBLE_EQ(crit[0].exp_above, 1.5) << "snap must not drop the 1.5 tag";
+}
+
 TEST(XSectBoundary, ShiftsMinYToZeroIncludingArcInterior) {
     // A small triangle up high, (-1,5)-(1,5)-(0,6), with the base replaced by
     // a semicircle bulge (b=1) that dips DOWN to y=4 at its midpoint — below


### PR DESCRIPTION
Adds findCriticalHeights: locates the depths where a section's geometry stops being smooth (rounded inverts, benches where the width jumps, crowns) and tags each one for the Chebyshev compiler's coordinate map. Splitting the depth range here is what makes the upcoming spectral fit converge fast instead of slowly.

The whole thing reduces to one rule — a 1.5 tag comes only from a smooth horizontal tangency, on the side where that arc lies. Corners never produce one, so the code never has to distinguish "corner vs. smooth joint", which would have been the brittle part.

Two spec corrections documented in the header: the 1.0/1.5 classification is genuinely incomplete (a V-notch invert is exponent 2.0, correctly tagged as analytic), and "a closed conduit's crown is always 1.5" is false for pointed/gothic crowns — the tag is now computed, not assumed.

9 tests, one per judgement call, mutation-checked (inverting the core rule breaks exactly 3).