### PR TITLE
feat(hydraulics): POLYGON cross-section shape + XSECT_GEOMETRY EXACT …

### DIFF
--- a/include/openswmm/engine/openswmm_links.h
+++ b/include/openswmm/engine/openswmm_links.h
@@ -99,7 +99,9 @@ typedef enum SWMM_XSectShape {
     SWMM_XSECT_CUSTOM          = 22, /**< Custom shape (from a shape curve).    geom1=height, geom2=shape-curve index. */
     SWMM_XSECT_FORCE_MAIN      = 23, /**< Circular force main.                  geom1=diameter, geom2=roughness (H-W C or D-W eps). */
     SWMM_XSECT_STREET          = 24, /**< Street cross-section (from [STREETS]). geom1=street index. */
-    SWMM_XSECT_DUMMY           = 25  /**< Dummy — no geometry; all queries return 0. */
+    SWMM_XSECT_DUMMY           = 25, /**< Dummy — no geometry; all queries return 0. */
+    SWMM_XSECT_POLYGON         = 26  /**< Arc/line boundary from a [CURVES] XPOLYGON entry, compressed to a
+                                           piecewise-Chebyshev series. geom1=scale, geom2=open-channel flag (0/1). */
 } SWMM_XSectShape;
 
 /* =========================================================================

--- a/src/engine/core/SWMMEngine.cpp
+++ b/src/engine/core/SWMMEngine.cpp
@@ -683,7 +683,8 @@ int SWMMEngine::initialize() noexcept {
         if (ctx_.links.type[uj] == LinkType::CONDUIT && q0 != 0.0) {
             const int cr = ctx_.link_subtypes.conduit_row(j);
             const auto& CD = ctx_.link_subtypes.conduits;
-            XSectParams xs = link::buildXSectParams(ctx_.links, uj, &ctx_.transect_tables);
+            XSectParams xs = link::buildXSectParams(ctx_.links, uj, &ctx_.transect_tables,
+                                                     &ctx_.cheb_sections);
             int barrels = (cr >= 0) ? CD.barrels[static_cast<std::size_t>(cr)] : 1;
             double q_per_barrel = std::fabs(q0) / std::max(barrels, 1);
             double beta = (cr >= 0) ? CD.beta[static_cast<std::size_t>(cr)] : 0.0;
@@ -784,7 +785,7 @@ int SWMMEngine::initialize() noexcept {
         ctx_.links.depth[uj]     = y;
         ctx_.links.old_depth[uj] = y;
         XSectParams xs = link::buildXSectParams(ctx_.links, uj,
-                                                &ctx_.transect_tables);
+                                                &ctx_.transect_tables, &ctx_.cheb_sections);
         const int cr = ctx_.link_subtypes.conduit_row(j);
         const auto& CD = ctx_.link_subtypes.conduits;
         int barrels = std::max((cr >= 0) ? CD.barrels[static_cast<std::size_t>(cr)] : 1, 1);
@@ -844,7 +845,7 @@ int SWMMEngine::initialize() noexcept {
                 double y = ctx_.links.depth[uj];
                 ctx_.links.old_depth[uj] = y;
                 XSectParams xs = link::buildXSectParams(ctx_.links, uj,
-                                                        &ctx_.transect_tables);
+                                                        &ctx_.transect_tables, &ctx_.cheb_sections);
                 const int cr = ctx_.link_subtypes.conduit_row(j);
                 const auto& CD = ctx_.link_subtypes.conduits;
                 int barrels = std::max((cr >= 0) ? CD.barrels[static_cast<std::size_t>(cr)] : 1, 1);
@@ -3266,7 +3267,7 @@ void SWMMEngine::ensureXspCache() noexcept {
     xsp_cache_.resize(n);
     for (std::size_t uj = 0; uj < n; ++uj)
         xsp_cache_[uj] = link::buildXSectParams(ctx_.links, uj,
-                                                &ctx_.transect_tables);
+                                                &ctx_.transect_tables, &ctx_.cheb_sections);
     xsp_cache_gen_ = ctx_.xsect_generation;
 }
 

--- a/src/engine/core/SimulationContext.hpp
+++ b/src/engine/core/SimulationContext.hpp
@@ -102,12 +102,15 @@
 #include "../data/InflowData.hpp"
 #include "../data/InfraData.hpp"
 #include "../hydraulics/Transect.hpp"
+#include "../hydraulics/XSectBoundary.hpp"
+#include "../hydraulics/ChebSection.hpp"
 #include "../data/HydrologyData.hpp"
 #include "../data/ForcingData.hpp"
 #include "../hydrology/Climate.hpp"
 
 #include <algorithm>
 #include <cstdint>
+#include <deque>
 #include <string>
 #include <utility>
 #include <vector>
@@ -676,6 +679,31 @@ struct SimulationContext {
     TransectStore    transects;
     /// Built transect geometry tables (indexed same as transects).
     std::vector<transect::TransectData> transect_tables;
+
+    /**
+     * @brief Compiled piecewise-Chebyshev cross-sections (Phase 4/5).
+     * @details One entry per distinct compiled boundary — every POLYGON
+     *          link's `[CURVES] XPOLYGON` curve (memoized by curve+scale, see
+     *          PostParseResolver), and, under `[OPTIONS] XSECT_GEOMETRY
+     *          EXACT`, one per distinct built-in shape geometry too.
+     *          `LinkData::xsect_cheb_idx` indexes into this. `std::deque`,
+     *          NOT `std::vector`: `XSectParams::cheb` holds raw pointers into
+     *          it, and a vector's reallocation-on-growth would dangle them —
+     *          mirroring the same stability concern already documented for
+     *          @ref transect_tables in XSectBatch.cpp. A deque never
+     *          invalidates existing elements on push_back, and ChebSection is
+     *          large enough (~26 kB) that deque's per-chunk overhead is
+     *          negligible.
+     */
+    std::deque<chebsec::ChebSection> cheb_sections;
+
+    /**
+     * @brief Source boundary (arcs/lines) behind each @ref cheb_sections
+     *        entry, indexed identically. Host-only; kept only so a boundary
+     *        can be recompiled later (e.g. Phase 7 run-time geometry
+     *        changes) without re-parsing the originating curve.
+     */
+    std::deque<std::vector<xsboundary::BElem>> cheb_boundaries;
     /// Bumped whenever a link's cross-section/flow properties are recomputed
     /// mid-run (C-API setters via recompute_conduit_flow_properties), so
     /// consumers holding per-link XSectParams caches know to rebuild

--- a/src/engine/core/SimulationOptions.hpp
+++ b/src/engine/core/SimulationOptions.hpp
@@ -131,6 +131,33 @@ enum class NodeContinuity : int {
     SEMI_IMPLICIT = 1   ///< Unified semi-implicit formulation
 };
 
+/**
+ * @brief Cross-section geometry backend (`[OPTIONS] XSECT_GEOMETRY`).
+ *
+ * @details Maintainer decision, 2026-08-19 (see project history): ship
+ *          alpha-gated, default LEGACY.
+ *  - LEGACY: every shape (built-in and POLYGON) evaluates through the
+ *    EPA-parity 51-point tables / closed-form formulas it always has.
+ *    `test_xsect_kernels_parity` runs in this mode — existing models see no
+ *    change.
+ *  - EXACT: every self-contained shape (built-in AND POLYGON) is compiled to
+ *    an exact arc/line boundary and evaluated through the piecewise-
+ *    Chebyshev path (chebAll). Parity with EPA SWMM 5 is INTENTIONALLY
+ *    broken at the ~1e-3-and-below level documented in the design notes —
+ *    the new numbers are more accurate, not bit-identical. Alpha /
+ *    experimental: no committed second regression baseline yet.
+ *
+ * Specified in [OPTIONS] as:
+ * @code
+ * XSECT_GEOMETRY  LEGACY  ;; default
+ * XSECT_GEOMETRY  EXACT
+ * @endcode
+ */
+enum class XsectGeometryMode : int {
+    LEGACY = 0,
+    EXACT  = 1
+};
+
 // ============================================================================
 // SimulationOptions struct
 // ============================================================================
@@ -344,6 +371,9 @@ struct SimulationOptions {
 
     /** @brief Node continuity formulation for depth update. Default: EXPLICIT (legacy). */
     NodeContinuity node_continuity = NodeContinuity::EXPLICIT;
+
+    /** @brief Cross-section geometry backend. Default: LEGACY (EPA parity). */
+    XsectGeometryMode xsect_geometry = XsectGeometryMode::LEGACY;
 
     /** @brief Virtual-junction momentum treatment. Always 0 (BASIC).
      *  @details BASIC applies zero storage, the shared junction sigma and

--- a/src/engine/core/openswmm_xsect_impl.cpp
+++ b/src/engine/core/openswmm_xsect_impl.cpp
@@ -69,6 +69,7 @@ using openswmm::transect::TransectData;
 struct XSectHandle {
     XSectParams  params{};
     TransectData table{};        ///< Owned; only populated for tabulated shapes.
+    openswmm::chebsec::ChebSection cheb{}; ///< Owned; only populated for a compiled boundary.
     XsectShape   shape = XsectShape::CIRCULAR;   ///< Public (storage) shape code.
     int          unit_system = 0;                ///< 0 = US, 1 = SI.
     int          flow_units  = 0;                ///< FlowUnits code (0..5).
@@ -131,12 +132,12 @@ bool valid_input(double v) { return std::isfinite(v) && v >= 0.0; }
 
 bool is_tabulated(XsectShape s) {
     return s == XsectShape::IRREGULAR || s == XsectShape::CUSTOM ||
-           s == XsectShape::STREET_XSECT;
+           s == XsectShape::STREET_XSECT || s == XsectShape::POLYGON;
 }
 
 bool valid_shape(int s) {
     return s >= static_cast<int>(XsectShape::CIRCULAR) &&
-           s <= static_cast<int>(XsectShape::DUMMY);
+           s <= static_cast<int>(XsectShape::POLYGON);
 }
 
 // ============================================================================
@@ -187,13 +188,13 @@ double k_area_of_sf(const XSectParams& p, double s)     { return openswmm::xsect
 double k_dsda(const XSectParams& p, double a)           { return openswmm::xsect::getdSdA(p, a); }
 double k_ycrit(const XSectParams& p, double q)          { return openswmm::xsect::getYcrit(p, q); }
 
-const char* const kShapeNames[26] = {
+const char* const kShapeNames[27] = {
     "CIRCULAR", "FILLED_CIRCULAR", "RECT_CLOSED", "RECT_OPEN", "TRAPEZOIDAL",
     "TRIANGULAR", "PARABOLIC", "POWER", "MODBASKETHANDLE", "EGGSHAPED",
     "HORSESHOE", "GOTHIC", "CATENARY", "SEMIELLIPTICAL", "BASKETHANDLE",
     "SEMICIRCULAR", "RECT_TRIANG", "RECT_ROUND", "HORIZ_ELLIPSE",
     "VERT_ELLIPSE", "ARCH", "IRREGULAR", "CUSTOM", "FORCE_MAIN",
-    "STREET_XSECT", "DUMMY"
+    "STREET_XSECT", "DUMMY", "POLYGON"
 };
 
 } // namespace
@@ -412,7 +413,8 @@ SWMM_ENGINE_API int swmm_link_create_xsect(SWMM_Engine engine, int link_idx,
     // buildXSectParams reads the geometry the engine actually resolved, so a
     // link handle reflects the model rather than re-deriving from raw geoms.
     h->params = openswmm::link::buildXSectParams(ctx.links, uidx,
-                                                 &ctx.transect_tables);
+                                                 &ctx.transect_tables,
+                                                 &ctx.cheb_sections);
 
     // ...but it takes the shape from links.xsect_batch_shape, which is a
     // hot-loop cache that SWMMEngine::initialize() fills — and then only for
@@ -435,6 +437,15 @@ SWMM_ENGINE_API int swmm_link_create_xsect(SWMM_Engine engine, int link_idx,
         h->params.hrad_tbl          = h->table.hrad_tbl;
         h->params.width_tbl         = h->table.width_tbl;
         h->params.transect_tbl_size = openswmm::transect::N_TRANSECT_TBL;
+    }
+
+    // Same lifetime concern for a compiled Chebyshev boundary: buildXSectParams
+    // aimed params.cheb into ctx.cheb_sections, which dies with the engine.
+    // ChebSection is POD/trivially copyable (see ChebSection.hpp), so take our
+    // own copy and re-point at it, exactly like the transect table above.
+    if (h->params.cheb) {
+        h->cheb = *h->params.cheb;
+        h->params.cheb = &h->cheb;
     }
 
     *out = h.release();

--- a/src/engine/data/LinkData.hpp
+++ b/src/engine/data/LinkData.hpp
@@ -93,7 +93,8 @@ enum class XsectShape : int16_t {
     CUSTOM           = 22,  ///< Shape from CURVE_SHAPE table
     FORCE_MAIN       = 23,  ///< Circular force main (Hazen-Williams or D-W)
     STREET_XSECT     = 24,  ///< Street cross-section
-    DUMMY            = 25   ///< Dummy (no geometry)
+    DUMMY            = 25,  ///< Dummy (no geometry)
+    POLYGON          = 26   ///< Arc/line boundary from a [CURVES] XPOLYGON entry
 };
 
 /**
@@ -208,6 +209,20 @@ struct LinkData {
      * @details -1 for standard shapes.
      */
     std::vector<int>        xsect_curve;
+
+    /**
+     * @brief Index into SimulationContext::cheb_sections, or -1.
+     * @details Set for every POLYGON link (always) and, under `[OPTIONS]
+     *          XSECT_GEOMETRY EXACT`, for every self-contained built-in
+     *          shape too — see PostParseResolver's boundary-reconstruction
+     *          pass. A link with `xsect_cheb_idx >= 0` evaluates entirely
+     *          through the Chebyshev path (XSectParams::cheb), bypassing the
+     *          legacy per-shape table/formula dispatch regardless of
+     *          @ref xsect_shape. Deliberately independent of @ref
+     *          xsect_curve, which stays reserved for the transect-table
+     *          index used by IRREGULAR/CUSTOM/STREET_XSECT.
+     */
+    std::vector<int>        xsect_cheb_idx;
 
     // Phase 6: conduit-config fields (roughness, length, slope, mod_length,
     // barrels, beta, rough_factor, q_full, q_max) moved to ConduitData in
@@ -574,6 +589,7 @@ struct LinkData {
         xsect_geom3.assign(un, 0.0);
         xsect_geom4.assign(un, 0.0);
         xsect_curve.assign(un, -1);
+        xsect_cheb_idx.assign(un, -1);
         xsect_r_full.assign(un, 0.0);
         xsect_s_full.assign(un, 0.0);
         xsect_s_max.assign(un, 0.0);
@@ -643,6 +659,7 @@ struct LinkData {
         g(xsect_y_full, 0.0); g(xsect_a_full, 0.0); g(xsect_w_max, 0.0);
         g(xsect_geom1, 0.0); g(xsect_geom2, 0.0); g(xsect_geom3, 0.0); g(xsect_geom4, 0.0);
         g(xsect_curve, -1);
+        g(xsect_cheb_idx, -1);
         g(xsect_r_full, 0.0); g(xsect_s_full, 0.0); g(xsect_s_max, 0.0);
         g(xsect_y_bot, 0.0); g(xsect_a_bot, 0.0);
         g(xsect_s_bot, 0.0); g(xsect_r_bot, 0.0);
@@ -701,7 +718,7 @@ struct LinkData {
         r(type); r(node1); r(node2); r(offset1);
         r(offset2); r(q0); r(q_limit); r(xsect_shape);
         r(xsect_y_full); r(xsect_a_full); r(xsect_w_max); r(xsect_geom1);
-        r(xsect_geom2); r(xsect_geom3); r(xsect_geom4); r(xsect_curve);
+        r(xsect_geom2); r(xsect_geom3); r(xsect_geom4); r(xsect_curve); r(xsect_cheb_idx);
         r(xsect_r_full); r(xsect_s_full); r(xsect_s_max); r(xsect_y_bot);
         r(xsect_a_bot); r(xsect_s_bot); r(xsect_r_bot); r(xsect_yw_max);
         r(xsect_batch_shape); r(setting); r(target_setting); r(time_last_set);
@@ -731,7 +748,7 @@ struct LinkData {
 
         e(type); e(node1); e(node2); e(offset1); e(offset2); e(q0); e(q_limit);
 
-        e(xsect_shape); e(xsect_y_full); e(xsect_a_full); e(xsect_w_max); e(xsect_curve);
+        e(xsect_shape); e(xsect_y_full); e(xsect_a_full); e(xsect_w_max); e(xsect_curve); e(xsect_cheb_idx);
         e(xsect_r_full); e(xsect_s_full); e(xsect_s_max);
         e(xsect_y_bot); e(xsect_a_bot); e(xsect_s_bot); e(xsect_r_bot); e(xsect_yw_max);
         e(xsect_batch_shape); e(setting); e(target_setting); e(direction);
@@ -826,6 +843,7 @@ struct LinkData {
         xsect_a_full.shrink_to_fit();
         xsect_w_max.shrink_to_fit();
         xsect_curve.shrink_to_fit();
+        xsect_cheb_idx.shrink_to_fit();
         xsect_r_full.shrink_to_fit();
         xsect_s_full.shrink_to_fit();
         xsect_s_max.shrink_to_fit();

--- a/src/engine/data/TableData.hpp
+++ b/src/engine/data/TableData.hpp
@@ -81,7 +81,8 @@ enum class TableType : int {
     CURVE_PUMP2   = 8,  ///< Pump curve type 2 (head vs flow)
     CURVE_PUMP3   = 9,  ///< Pump curve type 3 (volume vs time)
     CURVE_PUMP4   = 10, ///< Pump curve type 4 (depth vs speed)
-    CURVE_PUMP5   = 11  ///< Pump curve type 5 (head vs flow, variable speed)
+    CURVE_PUMP5   = 11, ///< Pump curve type 5 (head vs flow, variable speed)
+    CURVE_XPOLYGON = 12 ///< POLYGON cross-section arc/line boundary curve
 };
 
 // ============================================================================
@@ -147,6 +148,26 @@ struct Table {
     std::vector<double> x;       ///< Independent variable (time, depth, etc.)
     std::vector<double> y;       ///< Dependent variable (flow, volume, etc.)
     TableCursor         cursor;  ///< Bidirectional lookup cursor
+
+    /**
+     * @brief Per-point DXF-convention bulge (CURVE_XPOLYGON only).
+     * @details Parallel to x/y: bulge[i] is the arc bulge for the segment
+     *          running from point i to point i+1 (0 = straight). Empty for
+     *          every other curve type — the row loop only fills it for
+     *          XPOLYGON, where a row's optional 3rd column feeds it.
+     */
+    std::vector<double> bulge;
+
+    /**
+     * @brief Resolved per-point column stride for CURVE_XPOLYGON (0 = not
+     *        yet decided, 2 = x,y pairs, 3 = x,y,bulge triples).
+     * @details Decided once, from the first data row's own token count, and
+     *          then held fixed for every later row of the same curve — a
+     *          row-by-row modulo re-decision would silently misparse a
+     *          6-token continuation row (divisible by both 2 and 3) as
+     *          triples even when every sibling row in the curve was pairs.
+     */
+    int                  xpolygon_stride = 0;
 
     // ---- File-backed time series support ----
     bool               is_file_based = false; ///< True if data is read from external file

--- a/src/engine/hydraulics/ChebSection.cpp
+++ b/src/engine/hydraulics/ChebSection.cpp
@@ -360,8 +360,26 @@ int compile(ChebSection& out, const BElem* elems, int n, bool is_open) {
     // below it.
     const ChebPiece& top = out.piece[out.n_pieces - 1];
     out.a_full = chebEval(top.c_a, top.n_a, 1.0);
-    const double p_full = chebEval(top.c_p, top.n_p, 1.0);
-    out.r_full = (p_full > 0.0) ? out.a_full / p_full : 0.0;
+
+    // Perimeter at the crown: for a CLOSED shape this is NOT the fitted
+    // series extrapolated to u=1. That series was built from strictly
+    // interior samples and only ever captures the open-channel-below-crown
+    // limit; a flat/cornered crown (Puiseux exponent 1.0) has a real jump at
+    // y_full between that limit and the pressurized-full perimeter (every
+    // boundary element wetted). A smooth ROUND crown (exponent 1.5) has no
+    // such jump, which is why this was invisible to the circle-only test
+    // suite. Sum every input element's own arcLength instead — well-defined
+    // regardless of the crown's smoothness, since it needs no extrapolation
+    // at all. An OPEN shape has no crown to pressurize past, so the fitted
+    // limit remains correct there (matches legacy RECT_OPEN's own r_full,
+    // which likewise excludes the open top).
+    if (is_open) {
+        out.p_full = chebEval(top.c_p, top.n_p, 1.0);
+    } else {
+        out.p_full = 0.0;
+        for (int i = 0; i < n; ++i) out.p_full += xsboundary::arcLength(elems[i]);
+    }
+    out.r_full = (out.p_full > 0.0) ? out.a_full / out.p_full : 0.0;
     out.s_full = out.a_full * std::pow(std::max(out.r_full, 0.0), 2.0 / 3.0);
 
     constexpr int kScan = 1000;

--- a/src/engine/hydraulics/ChebSection.hpp
+++ b/src/engine/hydraulics/ChebSection.hpp
@@ -196,6 +196,29 @@ struct ChebSection {
     double s_max = 0.0;    ///< maximum section factor
     double a_max = 0.0;    ///< area at which s_max occurs (ft^2)
 
+    /// Wetted perimeter AT y_full (ft).
+    /// @note NOT simply "the fitted P(y) series evaluated at its own y_full
+    ///       endpoint". For a CLOSED shape with a flat/cornered crown (Puiseux
+    ///       exponent 1.0 at the top — see XSectBoundary.hpp), P(y) has a real
+    ///       physical jump at y_full: just below the crown the water hasn't
+    ///       touched the top wall yet (wetted perimeter = bottom + side walls
+    ///       only), while AT y_full the section is pressurized-full (every
+    ///       boundary element wetted). The fit is built from strictly-interior
+    ///       samples and only ever captures the BELOW-crown limit, so
+    ///       extrapolating it to u=1 silently returns the wrong (smaller)
+    ///       perimeter — undercounting r_full/s_full by exactly the missing
+    ///       crown width. A smooth ROUND crown (exponent 1.5) has no such
+    ///       jump — the wetted arc already sweeps almost the entire circle as
+    ///       y -> y_full, so the fitted limit is correct there, which is why
+    ///       this was never caught by the circle-only Phase 4 test suite.
+    ///       compile() sets this to the TRUE closed-loop perimeter (every
+    ///       input BElem's arcLength summed, unconditionally) for a closed
+    ///       shape, and to the ordinary fitted limit for an open one (an open
+    ///       top is never a wall, so there is no discontinuity to correct).
+    ///       chebPofY/chebAll read this field directly for y >= y_full rather
+    ///       than re-deriving it, so every caller sees the same value.
+    double p_full = 0.0;
+
     ChebPiece piece[kMaxPieces];
 };
 
@@ -387,9 +410,12 @@ OPENSWMM_KERNEL_FN double chebWofY(const ChebSection& s, double y) noexcept {
 
 OPENSWMM_KERNEL_FN double chebPofY(const ChebSection& s, double y) noexcept {
     if (y <= 0.0 || s.n_pieces <= 0) return 0.0;
-    const double yy = (y >= s.y_full) ? s.y_full : y;
-    const ChebPiece& pc = s.piece[chebPieceOfY(s, yy)];
-    const double p = chebEval(pc.c_p, pc.n_p, chebUofY(pc, yy));
+    // At or above the crown, P jumps for a closed shape (see ChebSection::
+    // p_full) — read the compile()-computed true value rather than
+    // extrapolating the fit, which only ever captures the below-crown limit.
+    if (y >= s.y_full) return s.p_full;
+    const ChebPiece& pc = s.piece[chebPieceOfY(s, y)];
+    const double p = chebEval(pc.c_p, pc.n_p, chebUofY(pc, y));
     return (p > 0.0) ? p : 0.0;
 }
 
@@ -429,6 +455,25 @@ OPENSWMM_KERNEL_FN double chebdAdY(const ChebSection& s, double y) noexcept {
     const double dydu = mapDsDu(u, pc.exp_lo, pc.exp_hi) / pc.inv_span;
     if (!(dydu > 1.0e-300)) return 0.0;
     return dAdu / dydu;
+}
+
+/// dP/dy from the P series' exact derivative — same construction as
+/// chebdAdY, over c_p/n_p instead of c_a/n_a.
+/// @note Not in the original Phase 4 design; added for Phase 5's getdSdA,
+///       which needs dR/dA = 1/P - (A/P^2)*dP/dA analytically (no finite
+///       differences) and dP/dA = (dP/dy)/(dA/dy).
+OPENSWMM_KERNEL_FN double chebdPdY(const ChebSection& s, double y) noexcept {
+    if (y <= 0.0 || y >= s.y_full || s.n_pieces <= 0) return 0.0;
+    const ChebPiece& pc = s.piece[chebPieceOfY(s, y)];
+    const double u = chebUofY(pc, y);
+
+    double dc[kMaxChebCoeff];
+    chebDeriv(pc.c_p, pc.n_p, dc);
+    const double dPdu = chebEval(dc, pc.n_p - 1, u);
+
+    const double dydu = mapDsDu(u, pc.exp_lo, pc.exp_hi) / pc.inv_span;
+    if (!(dydu > 1.0e-300)) return 0.0;
+    return dPdu / dydu;
 }
 
 /// Invert A -> y. Newton on the exact derivative, safeguarded by bisection.
@@ -477,7 +522,8 @@ OPENSWMM_KERNEL_FN void chebAll(const ChebSection& s, double y,
         const ChebPiece& top = s.piece[s.n_pieces - 1];
         *A = s.a_full;
         *W = chebEval(top.c_w, top.n_w, 1.0);
-        *P = chebEval(top.c_p, top.n_p, 1.0);
+        // s.p_full, not the fitted extrapolation — see ChebSection::p_full.
+        *P = s.p_full;
         *I1 = chebEval(top.c_i1, top.n_i1, 1.0) + s.a_full * (y - s.y_full);
         if (*W < 0.0) *W = 0.0;
         if (*P < 0.0) *P = 0.0;

--- a/src/engine/hydraulics/DynamicWave.cpp
+++ b/src/engine/hydraulics/DynamicWave.cpp
@@ -51,6 +51,7 @@
  */
 
 #include "DynamicWave.hpp"
+#include "Link.hpp"
 #include "Node.hpp"
 #include "Outfall.hpp"
 #include "XSectBatch.hpp"
@@ -482,10 +483,25 @@ void DWSolver::init(int n_nodes, int n_links, const XSectGroups& groups,
         const auto ucr = static_cast<std::size_t>(ctx.link_subtypes.conduit_row(j));
         XsectShape shape = links.xsect_shape[uj];
 
-        is_open_[uj] = (shape == XsectShape::RECT_OPEN ||
-                        shape == XsectShape::TRAPEZOIDAL ||
-                        shape == XsectShape::TRIANGULAR ||
-                        shape == XsectShape::PARABOLIC);
+        // POLYGON carries no shape code isOpen(int) can classify — a compiled
+        // boundary's own is_open is authoritative there (mirrors the cheb-vs-
+        // shape fallback in recomputeConduitLossOne below). Every other shape
+        // keeps the plain shape-code test; this precompute feeds is_open_/
+        // tile_is_open_, which every DYNWAVE crown-cap and slot-exclusion
+        // check downstream reads, so getting it right here is what makes an
+        // open POLYGON channel behave like RECT_OPEN instead of like a closed
+        // pipe throughout the rest of this file.
+        if (shape == XsectShape::POLYGON) {
+            const int ci = links.xsect_cheb_idx[uj];
+            is_open_[uj] =
+                (ci >= 0 && static_cast<std::size_t>(ci) < ctx.cheb_sections.size()) &&
+                ctx.cheb_sections[static_cast<std::size_t>(ci)].is_open;
+        } else {
+            is_open_[uj] = (shape == XsectShape::RECT_OPEN ||
+                            shape == XsectShape::TRAPEZOIDAL ||
+                            shape == XsectShape::TRIANGULAR ||
+                            shape == XsectShape::PARABOLIC);
+        }
         is_force_main_[uj] = (shape == XsectShape::FORCE_MAIN);
         has_losses_[uj] = (CD.loss_inlet[ucr] != 0.0 ||
                            CD.loss_outlet[ucr] != 0.0 ||
@@ -1406,9 +1422,12 @@ void DWSolver::findBypassedLinks(const SimulationContext& ctx) {
 static XSectParams buildXSP(const SimulationContext& ctx, std::size_t uk) {
     const LinkData& links = ctx.links;
     XSectParams xs{};
-    // Translate LinkData enum (CIRCULAR=0) to batch enum (CIRCULAR=1)
     auto ls = links.xsect_shape[uk];
-    xs.type = (ls == XsectShape::DUMMY) ? 0 : static_cast<int>(ls) + 1;
+    // link::translateShape is the canonical LinkData-enum -> batch-enum
+    // translation (Link.cpp) — POLYGON=26 was appended to both enums at the
+    // same numeric value, breaking the flat +1 offset every earlier shape
+    // follows, so this delegates rather than re-deriving the mapping here.
+    xs.type = link::translateShape(ls);
     xs.y_full = links.xsect_y_full[uk];
     xs.a_full = links.xsect_a_full[uk];
     xs.w_max  = links.xsect_w_max[uk];
@@ -1443,6 +1462,14 @@ static XSectParams buildXSP(const SimulationContext& ctx, std::size_t uk) {
             xs.width_tbl       = td.width_tbl;
             xs.transect_tbl_size = transect::N_TRANSECT_TBL;
         }
+    }
+    // Compiled Chebyshev boundary: every POLYGON link, and, under
+    // XSECT_GEOMETRY EXACT, any other shape too. Same "otherwise the scalar
+    // getters return 0" reasoning as the transect-table block above.
+    {
+        const int ci = links.xsect_cheb_idx[uk];
+        if (ci >= 0 && static_cast<std::size_t>(ci) < ctx.cheb_sections.size())
+            xs.cheb = &ctx.cheb_sections[static_cast<std::size_t>(ci)];
     }
     return xs;
 }
@@ -1552,8 +1579,12 @@ void DWSolver::computeLinkGeometry(SimulationContext& ctx) {
         // STEP B prep — fused inline. yCap is the EXTRAN crown cap; SLOT
         // mode disables it (yCap = ∞). Branchless via select.
         if (!slot_mode) {
-            const int bs = tile_xsect_batch_shape_[uci];
-            const bool is_open = xsect::isOpen(bs);
+            // tile_is_open_ (not xsect::isOpen(int) on the shape code) is
+            // POLYGON-correct — a compiled boundary's open/closed-ness is a
+            // property of the ChebSection, not the shape code, and this
+            // precomputed value already accounts for that (see is_open_'s
+            // init in refreshConduitTile).
+            const bool is_open = tile_is_open_[uci];
             const double yCap = (!is_open && yf > 0.0) ? EXTRAN_CROWN_CUTOFF * yf : 1e30;
             wcap_d1_[uj] = std::min(y1,   yCap);
             wcap_d2_[uj] = std::min(y2,   yCap);
@@ -1819,7 +1850,7 @@ void DWSolver::computeLinkGeometry(SimulationContext& ctx) {
                 if (wSlotM > 0.0)
                     wMsa = wSlotM;
                 else if (yMid / yf >= getCrownCutoff() &&
-                         !xsect::isOpen(tile_xsect_batch_shape_[uci]))
+                         !xsect::isOpen(xs))
                     wMsa = xsect::getWofY(xs, getCrownCutoff() * yf);
                 else
                     wMsa = wM;
@@ -1853,7 +1884,7 @@ void DWSolver::computeLinkGeometry(SimulationContext& ctx) {
                 if (wSlotM > 0.0)
                     wMsa = wSlotM;
                 else if (yMid / yf >= getCrownCutoff() &&
-                         !xsect::isOpen(tile_xsect_batch_shape_[uci]))
+                         !xsect::isOpen(xs))
                     wMsa = xsect::getWofY(xs, getCrownCutoff() * yf);
                 else
                     wMsa = wM;
@@ -2020,7 +2051,17 @@ void DWSolver::recomputeConduitLossOne(SimulationContext& ctx, double dt,
             if (length <= 0.0) length = CD.mod_length[uci];
             const int shape = links.xsect_batch_shape[u];
 
-            const bool wantEvap = xsect::isOpen(shape) && evap > 0.0;
+            // isOpen(int) can't classify a compiled boundary (POLYGON, or any
+            // shape under XSECT_GEOMETRY EXACT) — its open/closed-ness is a
+            // property of the specific ChebSection, not the shape code. Look
+            // that up directly rather than building the full XSectParams just
+            // for this early-exit check.
+            const int cheb_idx = links.xsect_cheb_idx[u];
+            const bool isOpenShape =
+                (cheb_idx >= 0 && static_cast<std::size_t>(cheb_idx) < ctx.cheb_sections.size())
+                    ? ctx.cheb_sections[static_cast<std::size_t>(cheb_idx)].is_open
+                    : xsect::isOpen(shape);
+            const bool wantEvap = isOpenShape && evap > 0.0;
             const bool wantSeep = CD.seep_rate[uci] > 0.0;
             if (wantEvap || wantSeep) {
                 const XSectParams xs = buildXSP(ctx, u);  // faithful incl. transect

--- a/src/engine/hydraulics/HydStructures.cpp
+++ b/src/engine/hydraulics/HydStructures.cpp
@@ -29,6 +29,7 @@
 #include "../core/SimulationContext.hpp"
 #include "../core/UnitConversion.hpp"
 #include "../math/SIMD.hpp"
+#include "Link.hpp"
 #include "Node.hpp"
 #include "XSectBatch.hpp"
 #include <cmath>
@@ -401,10 +402,14 @@ void StructureSolver::computePumpFlowK(SimulationContext& ctx, double dt,
 // Helper: build XSectParams from link SoA data
 // ============================================================================
 
-static XSectParams buildXSP(const LinkData& links, std::size_t uk) {
+static XSectParams buildXSP(const SimulationContext& ctx, std::size_t uk) {
+    const LinkData& links = ctx.links;
     XSectParams xs{};
-    auto ls = links.xsect_shape[uk];
-    xs.type = (ls == XsectShape::DUMMY) ? 0 : static_cast<int>(ls) + 1;
+    // link::translateShape is the canonical LinkData-enum -> batch-enum
+    // translation (Link.cpp) — POLYGON=26 was appended to both enums at the
+    // same numeric value, breaking the flat +1 offset every earlier shape
+    // follows, so this delegates rather than re-deriving the mapping here.
+    xs.type = link::translateShape(links.xsect_shape[uk]);
     xs.y_full = links.xsect_y_full[uk];
     xs.a_full = links.xsect_a_full[uk];
     xs.w_max  = links.xsect_w_max[uk];
@@ -415,6 +420,11 @@ static XSectParams buildXSP(const LinkData& links, std::size_t uk) {
     xs.a_bot  = links.xsect_a_bot[uk];
     xs.s_bot  = links.xsect_s_bot[uk];
     xs.r_bot  = links.xsect_r_bot[uk];
+    {
+        const int ci = links.xsect_cheb_idx[uk];
+        if (ci >= 0 && static_cast<std::size_t>(ci) < ctx.cheb_sections.size())
+            xs.cheb = &ctx.cheb_sections[static_cast<std::size_t>(ci)];
+    }
     return xs;
 }
 
@@ -496,7 +506,7 @@ void StructureSolver::computeOrificeFlowK(SimulationContext& ctx,
         }
 
         // Use xsect::getAofY for proper cross-section area at partial opening
-        XSectParams xs = buildXSP(links, uj);
+        XSectParams xs = buildXSP(ctx, uj);
         double a_eff = xsect::getAofY(xs, h_open);
         double f_area = a_eff * std::sqrt(2.0 * GRAVITY);
         double cOrif = cd_val * f_area;

--- a/src/engine/hydraulics/KinematicWave.cpp
+++ b/src/engine/hydraulics/KinematicWave.cpp
@@ -33,6 +33,7 @@
  */
 
 #include "KinematicWave.hpp"
+#include "Link.hpp"
 #include "XSectBatch.hpp"
 #include "../core/SimulationContext.hpp"
 #include "Node.hpp"
@@ -215,10 +216,14 @@ int KWSolver::solveConduit(int idx, const XSectParams& xs,
 // ============================================================================
 
 /// Build XSectParams from link SoA data (matching DynamicWave.cpp::buildXSP).
-static XSectParams buildXSP_KW(const LinkData& links, std::size_t uk) {
+static XSectParams buildXSP_KW(const SimulationContext& ctx, std::size_t uk) {
+    const LinkData& links = ctx.links;
     XSectParams xs{};
-    auto ls = links.xsect_shape[uk];
-    xs.type = (ls == XsectShape::DUMMY) ? 0 : static_cast<int>(ls) + 1;
+    // link::translateShape is the canonical LinkData-enum -> batch-enum
+    // translation (Link.cpp) — POLYGON=26 was appended to both enums at the
+    // same numeric value, breaking the flat +1 offset every earlier shape
+    // follows, so this delegates rather than re-deriving the mapping here.
+    xs.type = link::translateShape(links.xsect_shape[uk]);
     xs.y_full = links.xsect_y_full[uk];
     xs.a_full = links.xsect_a_full[uk];
     xs.w_max  = links.xsect_w_max[uk];
@@ -229,6 +234,11 @@ static XSectParams buildXSP_KW(const LinkData& links, std::size_t uk) {
     xs.a_bot  = links.xsect_a_bot[uk];
     xs.s_bot  = links.xsect_s_bot[uk];
     xs.r_bot  = links.xsect_r_bot[uk];
+    {
+        const int ci = links.xsect_cheb_idx[uk];
+        if (ci >= 0 && static_cast<std::size_t>(ci) < ctx.cheb_sections.size())
+            xs.cheb = &ctx.cheb_sections[static_cast<std::size_t>(ci)];
+    }
     return xs;
 }
 
@@ -298,7 +308,7 @@ int KWSolver::execute(SimulationContext& ctx, double dt) {
         double qin_per_barrel = qin / barrels;
 
         // Build XSectParams for this conduit
-        XSectParams xs = buildXSP_KW(links, uj);
+        XSectParams xs = buildXSP_KW(ctx, uj);
 
         double q_full = CD.q_full[ucr];
         double a_full = links.xsect_a_full[uj];

--- a/src/engine/hydraulics/LegacyShapeBoundary.cpp
+++ b/src/engine/hydraulics/LegacyShapeBoundary.cpp
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Copyright 2026 Caleb Buahin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "LegacyShapeBoundary.hpp"
+#include "XSectKernels.hpp"
+
+#include <cmath>
+
+namespace openswmm::xsboundary {
+
+namespace {
+
+constexpr double kPi = 3.14159265358979323846;
+
+/// Four quarter-arc points, each bulging by tan(pi/8) (a 90-degree sweep) —
+/// a TRUE circle, replacing the 26-point A_Circ/W_Circ/R_Circ tables.
+/// Diameter = xs.y_full (already the resolved full depth for both CIRCULAR
+/// and FORCE_MAIN).
+bool buildCircle(double y_full, std::vector<BElem>& out) {
+    if (y_full <= 0.0) return false;
+    // fromArcSpec requires n >= 3, so a circle needs at least 3 points — two
+    // antipodal points with bulge=1 each (a valid *closed loop* in principle)
+    // is rejected outright. Four quarter-arc points, each bulging by
+    // tan(pi/8) (a 90-degree sweep), is the same construction
+    // test_xsect_boundary.cpp's FourQuarterArcBulgesFormAFullCircle already
+    // proves traces an exact circle CCW.
+    const double r = 0.5 * y_full;
+    const double b = std::tan(0.25 * kPi / 2.0);   // tan(theta/4), theta = pi/2
+    const double x[4] = {r, 0.0, -r, 0.0};
+    const double y[4] = {0.0, r, 0.0, -r};
+    const double bulge[4] = {b, b, b, b};
+    return fromArcSpec(x, y, bulge, 4, out) == 0;
+}
+
+/// Ceiling on how many of a table's OWN points feed the polyline. Every
+/// vertex in a straight-line-only polyline is a generic corner (Puiseux
+/// exponent 1.0 — see XSectBoundary.hpp), so it is its own critical height;
+/// a table with N points mirrored into a symmetric polygon needs N-1 pieces
+/// just for the base split, with NO headroom left for compile()'s adaptive
+/// subdivision. `kMaxPieces` (ChebSection.hpp) is 24, sized — per its own
+/// documentation — for "a handful of arcs", not dense tabulated point
+/// clouds; EGG/HORSESHOE/BASKETHANDLE/ARCH/HORIZ_ELLIPSE/VERT_ELLIPSE all
+/// carry 26 raw table points, which need 25 pieces and blow the budget by
+/// exactly one (compile() error 5), while GOTHIC/CATENARY/SEMIELLIPTICAL/
+/// SEMICIRCULAR's 21-point tables just barely fit with zero headroom.
+/// Rather than raise a shared, carefully-sized constant for six shapes,
+/// subsample here: always keep the invert and crown (index 0 and n-1)
+/// EXACTLY, since those are where the boundary's own singular/critical
+/// behaviour lives and the table's own value there matters most, and
+/// evenly thin the interior down to kMaxTablePoints. This still uses only
+/// the table's OWN data (no invented geometry) and the smooth Chebyshev fit
+/// between coarser samples remains far better than legacy's own LINEAR
+/// interpolation between the denser ones, especially at the endpoints.
+constexpr int kMaxTablePoints = 13;
+
+/// Symmetric polyline from a shape's own normalized width table (thinned to
+/// at most kMaxTablePoints per the note above): right side ascending
+/// (invert to crown), left side descending (crown to invert).
+///
+/// @note A zero-width table endpoint (the usual case at the invert and/or
+///       crown of a closed ovoid shape — e.g. EGG's W_Egg[0] and W_Egg[last]
+///       are both 0) makes the right side's terminal point and the left
+///       side's starting point COINCIDE exactly, producing a zero-length
+///       segment. fromPolyline's pairwise segment check flags that as
+///       self-intersecting (two segments sharing an endpoint with zero
+///       separation) rather than the harmless degenerate vertex it actually
+///       is — caught by test_legacy_shape_boundary.cpp when every one of the
+///       10 width-table shapes failed to build. Fixed by simply not emitting
+///       a point that coincides with the one already at the end of the
+///       list (checked here rather than in fromPolyline, since a coincident
+///       *interior* vertex is a real, meaningful degenerate case elsewhere
+///       in that function and not something to special-case there). The
+///       same check runs once more after the loop for the closing edge
+///       (last point vs. first — fromPolyline closes the loop implicitly).
+bool buildFromWidthTable(const double* w_table, int n, double y_full,
+                         double w_max, std::vector<BElem>& out) {
+    if (n < 2 || y_full <= 0.0 || w_max <= 0.0) return false;
+
+    // Thinned index list: index 0 and n-1 exact, interior evenly spaced.
+    const int m = (n <= kMaxTablePoints) ? n : kMaxTablePoints;
+    std::vector<int> idx(static_cast<std::size_t>(m));
+    for (int k = 0; k < m; ++k) {
+        idx[static_cast<std::size_t>(k)] = (m == 1) ? 0 :
+            static_cast<int>(std::lround(static_cast<double>(k) *
+                                         static_cast<double>(n - 1) /
+                                         static_cast<double>(m - 1)));
+    }
+
+    std::vector<double> px, py;
+    px.reserve(static_cast<std::size_t>(2 * m));
+    py.reserve(static_cast<std::size_t>(2 * m));
+
+    constexpr double kCoincidentTol = 1.0e-12;
+    auto appendIfDistinct = [&](double x, double y) {
+        if (!px.empty()) {
+            const double dx = x - px.back();
+            const double dy = y - py.back();
+            if (dx * dx + dy * dy < kCoincidentTol) return;
+        }
+        px.push_back(x);
+        py.push_back(y);
+    };
+
+    const double inv_n1 = 1.0 / static_cast<double>(n - 1);
+    for (int k = 0; k < m; ++k) {
+        const int i = idx[static_cast<std::size_t>(k)];
+        const double y_norm = static_cast<double>(i) * inv_n1;
+        double half_w = 0.5 * w_table[i] * w_max;
+        if (half_w < 0.0) half_w = 0.0;
+        appendIfDistinct(half_w, y_norm * y_full);
+    }
+    for (int k = m - 1; k >= 0; --k) {
+        const int i = idx[static_cast<std::size_t>(k)];
+        const double y_norm = static_cast<double>(i) * inv_n1;
+        double half_w = 0.5 * w_table[i] * w_max;
+        if (half_w < 0.0) half_w = 0.0;
+        appendIfDistinct(-half_w, y_norm * y_full);
+    }
+    // Closing edge: drop the last point if it coincides with the first —
+    // fromPolyline connects them implicitly either way.
+    if (px.size() >= 2) {
+        const double dx = px.back() - px.front();
+        const double dy = py.back() - py.front();
+        if (dx * dx + dy * dy < kCoincidentTol) {
+            px.pop_back();
+            py.pop_back();
+        }
+    }
+
+    return fromPolyline(px.data(), py.data(), static_cast<int>(px.size()), out) == 0;
+}
+
+} // namespace
+
+bool buildLegacyBoundary(XSectShape shape, const XSectParams& xs,
+                         std::vector<BElem>& out) {
+    const xsect::XsectTables& tbl = xsect::hostTables();
+
+    switch (shape) {
+        case XSectShape::CIRCULAR:
+        case XSectShape::FORCE_MAIN:
+            return buildCircle(xs.y_full, out);
+
+        case XSectShape::EGGSHAPED:
+            return buildFromWidthTable(tbl.W_Egg, tbl.N_W_Egg, xs.y_full, xs.w_max, out);
+        case XSectShape::HORSESHOE:
+            return buildFromWidthTable(tbl.W_Horseshoe, tbl.N_W_Horseshoe, xs.y_full, xs.w_max, out);
+        case XSectShape::GOTHIC:
+            return buildFromWidthTable(tbl.W_Gothic, tbl.N_W_Gothic, xs.y_full, xs.w_max, out);
+        case XSectShape::CATENARY:
+            return buildFromWidthTable(tbl.W_Catenary, tbl.N_W_Catenary, xs.y_full, xs.w_max, out);
+        case XSectShape::SEMIELLIPTICAL:
+            return buildFromWidthTable(tbl.W_SemiEllip, tbl.N_W_SemiEllip, xs.y_full, xs.w_max, out);
+        case XSectShape::BASKETHANDLE:
+            return buildFromWidthTable(tbl.W_BasketHandle, tbl.N_W_BasketHandle, xs.y_full, xs.w_max, out);
+        case XSectShape::SEMICIRCULAR:
+            return buildFromWidthTable(tbl.W_SemiCirc, tbl.N_W_SemiCirc, xs.y_full, xs.w_max, out);
+        case XSectShape::ARCH:
+            return buildFromWidthTable(tbl.W_Arch, tbl.N_W_Arch, xs.y_full, xs.w_max, out);
+        case XSectShape::HORIZ_ELLIPSE:
+            return buildFromWidthTable(tbl.W_HorizEllipse, tbl.N_W_HorizEllipse, xs.y_full, xs.w_max, out);
+        case XSectShape::VERT_ELLIPSE:
+            return buildFromWidthTable(tbl.W_VertEllipse, tbl.N_W_VertEllipse, xs.y_full, xs.w_max, out);
+
+        default:
+            return false;
+    }
+}
+
+} // namespace openswmm::xsboundary

--- a/src/engine/hydraulics/LegacyShapeBoundary.hpp
+++ b/src/engine/hydraulics/LegacyShapeBoundary.hpp
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Copyright 2026 Caleb Buahin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file LegacyShapeBoundary.hpp
+ * @brief Reconstructs an exact arc/line boundary for a handful of built-in
+ *        shapes, so `[OPTIONS] XSECT_GEOMETRY EXACT` can evaluate them through
+ *        the same piecewise-Chebyshev path (chebAll) as POLYGON.
+ *
+ * @details Scope is deliberately narrower than "every shape": a shape's
+ *          LEGACY path already carries zero interpolation error when it is a
+ *          closed-form formula (RECT_CLOSED, RECT_OPEN, TRAPEZOIDAL,
+ *          TRIANGULAR, PARABOLIC, POWERFUNC, RECT_TRIANG, RECT_ROUND,
+ *          MOD_BASKET all compute A/W/R analytically from geometry
+ *          parameters, not from a table) — recompiling those buys nothing.
+ *          EXACT mode has real accuracy to gain only where the LEGACY path is
+ *          a linearly-interpolated TABLE:
+ *            - CIRCULAR / FORCE_MAIN: reconstructed as a TRUE circle (four
+ *              exact quarter-circle arcs — fromArcSpec requires n >= 3
+ *              points, so two antipodal points cannot express it) rather
+ *              than the 26-point A_Circ/W_Circ/R_Circ tables.
+ *            - EGGSHAPED, HORSESHOE, GOTHIC, CATENARY, SEMIELLIPTICAL,
+ *              BASKETHANDLE, SEMICIRCULAR, ARCH, HORIZ_ELLIPSE, VERT_ELLIPSE:
+ *              reconstructed from each shape's OWN existing normalized width
+ *              table (xsect_tables.hpp) as a symmetric polyline — the same
+ *              source data test_cheb_section.cpp's "Legacy parity" test uses
+ *              to validate a POLYGON reconstruction of EGG against its
+ *              tabulated legacy A/R/W. This is table-driven, not invented
+ *              geometry: it uses exactly the data the engine already ships,
+ *              at the ~26-point resolution EPA's own tables provide, then
+ *              lets the Chebyshev fit interpolate BETWEEN those points with
+ *              a smooth, physically-motivated polynomial in place of
+ *              linear segments.
+ *          FILLED_CIRCULAR and IRREGULAR/CUSTOM/STREET_XSECT/POLYGON are out
+ *          of scope here (the first needs a circular-segment construction not
+ *          yet implemented; the rest are already per-instance tabulated data,
+ *          not a shared built-in table, so "compiling the built-in" does not
+ *          apply to them).
+ *
+ * @note Whether a returned boundary should be treated as an open channel is
+ *       answered by the SAME classification `xsect::isOpen(int)` already
+ *       uses (RECT_OPEN/TRAPEZOIDAL/TRIANGULAR/PARABOLIC/POWERFUNC/IRREGULAR)
+ *       — none of the shapes this module supports are open, so the caller
+ *       always compiles them with `is_open = false`.
+ *
+ * @see XSectBoundary.hpp for the exact arc/line primitives this builds on.
+ * @see ChebSection.hpp for the compiler this boundary feeds.
+ * @ingroup engine_hydraulics
+ *
+ * @author   Claude (Anthropic), for the openswmm.engine project
+ * @copyright Copyright (c) 2026 Caleb Buahin. All rights reserved.
+ * @license  Apache-2.0
+ */
+
+#ifndef OPENSWMM_LEGACY_SHAPE_BOUNDARY_HPP
+#define OPENSWMM_LEGACY_SHAPE_BOUNDARY_HPP
+
+#include <vector>
+
+#include "XSectBatch.hpp"
+#include "XSectBoundary.hpp"
+
+namespace openswmm::xsboundary {
+
+/**
+ * @brief Build an exact boundary for a built-in shape, if this module
+ *        supports it.
+ *
+ * @param shape    the BATCH XSectShape code.
+ * @param xs       XSectParams AFTER xsect::setParams() has already resolved
+ *                 y_full/w_max/y_bot/r_bot/s_bot from the raw [XSECTIONS]
+ *                 geometry — this function reads only already-derived
+ *                 fields, never the raw geom1-4 array.
+ * @param[out] out destination boundary chain (fromArcSpec/fromPolyline
+ *                 output — CCW-oriented, min(y) == 0).
+ * @returns true if @p shape is supported and @p out was populated;
+ *          false if this shape's legacy path is already exact (or is
+ *          otherwise out of this module's scope) and the caller should keep
+ *          evaluating it through the ordinary table/formula dispatch.
+ */
+bool buildLegacyBoundary(XSectShape shape, const XSectParams& xs,
+                         std::vector<BElem>& out);
+
+} // namespace openswmm::xsboundary
+
+#endif // OPENSWMM_LEGACY_SHAPE_BOUNDARY_HPP

--- a/src/engine/hydraulics/Link.cpp
+++ b/src/engine/hydraulics/Link.cpp
@@ -63,6 +63,7 @@ int translateShape(XsectShape s) {
         case XsectShape::FORCE_MAIN:      return static_cast<int>(XSectShape::FORCE_MAIN);
         case XsectShape::STREET_XSECT:    return static_cast<int>(XSectShape::STREET_XSECT);
         case XsectShape::DUMMY:           return static_cast<int>(XSectShape::DUMMY);
+        case XsectShape::POLYGON:         return static_cast<int>(XSectShape::POLYGON);
         default:                          return static_cast<int>(XSectShape::DUMMY);
     }
 }
@@ -89,7 +90,7 @@ double getFroude(const XSectParams& xs, double v, double y) {
     if (y <= constants::FUDGE) return 0.0;
 
     // For closed conduits: return 0 if full
-    if (!xsect::isOpen(xs.type) && (xs.y_full - y) <= constants::FUDGE)
+    if (!xsect::isOpen(xs) && (xs.y_full - y) <= constants::FUDGE)
         return 0.0;
 
     // Hydraulic depth D_h = A / T
@@ -163,7 +164,8 @@ double getHydPower(double flow, double head_upstream, double head_downstream) {
 
 XSectParams buildXSectParams(
     const LinkData& links, std::size_t uj,
-    const std::vector<transect::TransectData>* transects) {
+    const std::vector<transect::TransectData>* transects,
+    const std::deque<chebsec::ChebSection>* cheb_sections) {
     XSectParams xs{};
     xs.type   = links.xsect_batch_shape[uj];
     xs.y_full = links.xsect_y_full[uj];
@@ -196,6 +198,17 @@ XSectParams buildXSectParams(
             xs.width_tbl         = td.width_tbl;
             xs.transect_tbl_size = transect::N_TRANSECT_TBL;
         }
+    }
+
+    // Attach the compiled Chebyshev boundary. Independent of xsect_curve
+    // above — xsect_cheb_idx is set for every POLYGON link, and for any
+    // other shape once XSECT_GEOMETRY EXACT compiles it too (see
+    // PostParseResolver). Once attached, every XsectEval accessor takes this
+    // path regardless of xs.type.
+    if (cheb_sections) {
+        const int ci = links.xsect_cheb_idx[uj];
+        if (ci >= 0 && static_cast<std::size_t>(ci) < cheb_sections->size())
+            xs.cheb = &(*cheb_sections)[static_cast<std::size_t>(ci)];
     }
     return xs;
 }

--- a/src/engine/hydraulics/Link.hpp
+++ b/src/engine/hydraulics/Link.hpp
@@ -37,7 +37,9 @@
 #include "XSectBatch.hpp"
 #include "Node.hpp"
 #include "Transect.hpp"
+#include "ChebSection.hpp"
 
+#include <deque>
 #include <vector>
 
 namespace openswmm {
@@ -137,11 +139,18 @@ double getHydPower(double flow, double head_upstream, double head_downstream);
  *                   A/R/W table pointers attached so the per-element accessors
  *                   can evaluate tabulated geometry. Pass nullptr when the link
  *                   is known to be a self-contained shape.
+ * @param cheb_sections  Optional compiled-boundary pool (ctx.cheb_sections).
+ *                   When supplied and `links.xsect_cheb_idx[uj] >= 0`,
+ *                   XSectParams::cheb is attached — every POLYGON link
+ *                   always qualifies; any other shape qualifies too once
+ *                   XSECT_GEOMETRY EXACT compiled it. Pass nullptr when the
+ *                   link is known to have no compiled boundary.
  * @returns Populated XSectParams struct.
  */
 XSectParams buildXSectParams(
     const LinkData& links, std::size_t uj,
-    const std::vector<transect::TransectData>* transects = nullptr);
+    const std::vector<transect::TransectData>* transects = nullptr,
+    const std::deque<chebsec::ChebSection>* cheb_sections = nullptr);
 
 // ============================================================================
 // Batch functions (for routing hot loop)

--- a/src/engine/hydraulics/Outfall.cpp
+++ b/src/engine/hydraulics/Outfall.cpp
@@ -66,6 +66,7 @@ static int translateShape(XsectShape link_shape) {
         case XsectShape::FORCE_MAIN:      return static_cast<int>(XSectShape::FORCE_MAIN);
         case XsectShape::STREET_XSECT:    return static_cast<int>(XSectShape::STREET_XSECT);
         case XsectShape::DUMMY:           return static_cast<int>(XSectShape::DUMMY);
+        case XsectShape::POLYGON:         return static_cast<int>(XSectShape::POLYGON);
         default:                          return static_cast<int>(XSectShape::DUMMY);
     }
 }
@@ -84,6 +85,9 @@ static XSectParams buildXSectParams(const SimulationContext& ctx, std::size_t uk
     xs.a_bot  = ctx.links.xsect_a_bot[uk];
     xs.s_bot  = ctx.links.xsect_s_bot[uk];
     xs.r_bot  = ctx.links.xsect_r_bot[uk];
+    const int ci = ctx.links.xsect_cheb_idx[uk];
+    if (ci >= 0 && static_cast<std::size_t>(ci) < ctx.cheb_sections.size())
+        xs.cheb = &ctx.cheb_sections[static_cast<std::size_t>(ci)];
     return xs;
 }
 

--- a/src/engine/hydraulics/Routing.cpp
+++ b/src/engine/hydraulics/Routing.cpp
@@ -51,10 +51,10 @@ namespace openswmm {
 // because the function is tiny and tightly coupled to the SoA layout.
 // ============================================================================
 
-static XSectParams buildXSP(const LinkData& links, std::size_t uk) {
+static XSectParams buildXSP(const SimulationContext& ctx, std::size_t uk) {
+    const LinkData& links = ctx.links;
     XSectParams xs{};
-    auto ls = links.xsect_shape[uk];
-    xs.type   = (ls == XsectShape::DUMMY) ? 0 : static_cast<int>(ls) + 1;
+    xs.type = link::translateShape(links.xsect_shape[uk]);
     xs.y_full = links.xsect_y_full[uk];
     xs.a_full = links.xsect_a_full[uk];
     xs.w_max  = links.xsect_w_max[uk];
@@ -65,6 +65,11 @@ static XSectParams buildXSP(const LinkData& links, std::size_t uk) {
     xs.a_bot  = links.xsect_a_bot[uk];
     xs.s_bot  = links.xsect_s_bot[uk];
     xs.r_bot  = links.xsect_r_bot[uk];
+    {
+        const int ci = links.xsect_cheb_idx[uk];
+        if (ci >= 0 && static_cast<std::size_t>(ci) < ctx.cheb_sections.size())
+            xs.cheb = &ctx.cheb_sections[static_cast<std::size_t>(ci)];
+    }
     return xs;
 }
 
@@ -78,50 +83,18 @@ void Router::init(SimulationContext& ctx, RouteModel model) {
     int n_links = ctx.n_links();
     int n_nodes = ctx.n_nodes();
 
-    // Build XSectParams array from ctx.links SoA fields
-    // NOTE: LinkData::XsectShape and XSectBatch::XSectShape have different
-    //       orderings. LinkData follows legacy enums.h (CIRCULAR=0), while
-    //       XSectBatch prepends DUMMY=0 and reorders some shapes.
-    //       Use explicit mapping to avoid misalignment.
-    auto translateShape = [](XsectShape link_shape) -> int {
-        switch (link_shape) {
-            case XsectShape::CIRCULAR:        return static_cast<int>(XSectShape::CIRCULAR);
-            case XsectShape::FILLED_CIRCULAR: return static_cast<int>(XSectShape::FILLED_CIRCULAR);
-            case XsectShape::RECT_CLOSED:     return static_cast<int>(XSectShape::RECT_CLOSED);
-            case XsectShape::RECT_OPEN:       return static_cast<int>(XSectShape::RECT_OPEN);
-            case XsectShape::TRAPEZOIDAL:     return static_cast<int>(XSectShape::TRAPEZOIDAL);
-            case XsectShape::TRIANGULAR:      return static_cast<int>(XSectShape::TRIANGULAR);
-            case XsectShape::PARABOLIC:       return static_cast<int>(XSectShape::PARABOLIC);
-            case XsectShape::POWER:           return static_cast<int>(XSectShape::POWERFUNC);
-            case XsectShape::MODBASKETHANDLE: return static_cast<int>(XSectShape::MOD_BASKET);
-            case XsectShape::EGGSHAPED:       return static_cast<int>(XSectShape::EGGSHAPED);
-            case XsectShape::HORSESHOE:       return static_cast<int>(XSectShape::HORSESHOE);
-            case XsectShape::GOTHIC:          return static_cast<int>(XSectShape::GOTHIC);
-            case XsectShape::CATENARY:        return static_cast<int>(XSectShape::CATENARY);
-            case XsectShape::SEMIELLIPTICAL:  return static_cast<int>(XSectShape::SEMIELLIPTICAL);
-            case XsectShape::BASKETHANDLE:    return static_cast<int>(XSectShape::BASKETHANDLE);
-            case XsectShape::SEMICIRCULAR:    return static_cast<int>(XSectShape::SEMICIRCULAR);
-            case XsectShape::RECT_TRIANG:     return static_cast<int>(XSectShape::RECT_TRIANG);
-            case XsectShape::RECT_ROUND:      return static_cast<int>(XSectShape::RECT_ROUND);
-            case XsectShape::HORIZ_ELLIPSE:   return static_cast<int>(XSectShape::HORIZ_ELLIPSE);
-            case XsectShape::VERT_ELLIPSE:    return static_cast<int>(XSectShape::VERT_ELLIPSE);
-            case XsectShape::ARCH:            return static_cast<int>(XSectShape::ARCH);
-            case XsectShape::IRREGULAR:       return static_cast<int>(XSectShape::IRREGULAR);
-            case XsectShape::CUSTOM:          return static_cast<int>(XSectShape::CUSTOM);
-            case XsectShape::FORCE_MAIN:      return static_cast<int>(XSectShape::FORCE_MAIN);
-            case XsectShape::STREET_XSECT:    return static_cast<int>(XSectShape::STREET_XSECT);
-            case XsectShape::DUMMY:           return static_cast<int>(XSectShape::DUMMY);
-            default:                          return static_cast<int>(XSectShape::DUMMY);
-        }
-    };
-
+    // Build XSectParams array from ctx.links SoA fields. LinkData::XsectShape
+    // and XSectBatch::XSectShape have different orderings (LinkData follows
+    // legacy enums.h with CIRCULAR=0; XSectBatch prepends DUMMY=0 and
+    // reorders some shapes) — link::translateShape (Link.cpp) is the single
+    // canonical mapping between them.
     std::vector<XSectParams> xsect_params(static_cast<std::size_t>(n_links));
     for (int j = 0; j < n_links; ++j) {
         auto uj = static_cast<std::size_t>(j);
         if (ctx.links.type[uj] != LinkType::CONDUIT) continue;
 
         auto& xs = xsect_params[uj];
-        xs.type   = translateShape(ctx.links.xsect_shape[uj]);
+        xs.type   = link::translateShape(ctx.links.xsect_shape[uj]);
         // Cache translated shape code to avoid per-timestep switch dispatch
         ctx.links.xsect_batch_shape[uj] = xs.type;
         xs.y_full = ctx.links.xsect_y_full[uj];
@@ -246,6 +219,10 @@ void Router::init(SimulationContext& ctx, RouteModel model) {
 
     // Attach transect tables for IRREGULAR cross-sections
     groups_.attachTransectTables(ctx);
+
+    // Attach compiled Chebyshev boundaries for POLYGON cross-sections (and,
+    // under XSECT_GEOMETRY EXACT, any other shape too).
+    groups_.attachChebSections(ctx);
 
     // Cache outfall → connecting-conduit mapping so setAllOutfallDepths
     // skips an O(n_links) inner scan on every Picard iteration.
@@ -562,6 +539,14 @@ void Router::computeConduitLosses(SimulationContext& ctx, double dt, double evap
             double length = CD.length[ucr];
             if (length <= 0.0) length = CD.mod_length[ucr];
             int batch_shape = links.xsect_batch_shape[uj];
+            // isOpen(int) can't classify a compiled boundary (POLYGON, or any
+            // shape under XSECT_GEOMETRY EXACT) — look up ChebSection::is_open
+            // directly rather than building a full XSectParams for this check.
+            const int cheb_idx = links.xsect_cheb_idx[uj];
+            const bool isOpenShape =
+                (cheb_idx >= 0 && static_cast<std::size_t>(cheb_idx) < ctx.cheb_sections.size())
+                    ? ctx.cheb_sections[static_cast<std::size_t>(cheb_idx)].is_open
+                    : xsect::isOpen(batch_shape);
 
             // Evaporation for open conduits only.
             //
@@ -579,7 +564,7 @@ void Router::computeConduitLosses(SimulationContext& ctx, double dt, double evap
             // The transect top-width below uses the linear approximation; the
             // faithful getWofY was tried and does NOT resolve the parity gap
             // (the gap is the timing, not the width). See PARITY_FINDINGS.
-            if (xsect::isOpen(batch_shape) && evap_rate > 0.0) {
+            if (isOpenShape && evap_rate > 0.0) {
                 double top_width = 0.0;
                 if (batch_shape == static_cast<int>(XSectShape::IRREGULAR) ||
                     batch_shape == static_cast<int>(XSectShape::CUSTOM)) {
@@ -592,6 +577,8 @@ void Router::computeConduitLosses(SimulationContext& ctx, double dt, double evap
                     xs.y_full = links.xsect_y_full[uj];
                     xs.a_full = links.xsect_a_full[uj];
                     xs.w_max  = links.xsect_w_max[uj];
+                    if (cheb_idx >= 0 && static_cast<std::size_t>(cheb_idx) < ctx.cheb_sections.size())
+                        xs.cheb = &ctx.cheb_sections[static_cast<std::size_t>(cheb_idx)];
                     top_width = xsect::getWofY(xs, depth);
                 }
                 evap_loss = top_width * length * evap_rate;
@@ -605,6 +592,8 @@ void Router::computeConduitLosses(SimulationContext& ctx, double dt, double evap
                 xs.a_full = links.xsect_a_full[uj];
                 xs.w_max  = links.xsect_w_max[uj];
                 xs.yw_max = links.xsect_yw_max[uj];
+                if (cheb_idx >= 0 && static_cast<std::size_t>(cheb_idx) < ctx.cheb_sections.size())
+                    xs.cheb = &ctx.cheb_sections[static_cast<std::size_t>(cheb_idx)];
 
                 double d_seep = depth;
                 // Limit depth to depth at max width (matching legacy)
@@ -719,7 +708,7 @@ int Router::executeSteadyFlow(SimulationContext& ctx, double dt) {
         if (q < 0.0) q = 0.0;
 
         // Build cross-section params once (used for getAofS and getYofA below).
-        XSectParams xs = buildXSP(links, uj);
+        XSectParams xs = buildXSP(ctx, uj);
 
         // Manning normal-depth area.
         double q_full = CD.q_full[ucr];

--- a/src/engine/hydraulics/XSectBatch.cpp
+++ b/src/engine/hydraulics/XSectBatch.cpp
@@ -105,7 +105,10 @@ void XSectGroups::build(const XSectParams* params, int n_links) {
     mask_active_ = false;
 
     // Count links per shape (skip DUMMY=0: non-conduit links that need no geometry)
-    constexpr int MAX_SHAPES = 26;
+    // One past the highest XSectShape value (POLYGON=26) — a link whose type
+    // lands exactly at MAX_SHAPES-1 must still be countable, so this is
+    // XSectShape::POLYGON + 1, not just "big enough".
+    constexpr int MAX_SHAPES = 27;
     int shape_count[MAX_SHAPES] = {};
     for (int i = 0; i < n_links; ++i) {
         int t = params[i].type;
@@ -191,6 +194,51 @@ void XSectGroups::attachTransectTables(const SimulationContext& ctx) {
                 g.a_full[uk] = td.a_full;
                 g.r_full[uk] = td.r_full;
                 g.w_max[uk]  = td.w_max;
+            }
+        }
+    }
+}
+
+void XSectGroups::attachChebSections(const SimulationContext& ctx) {
+    // Same lazy-mirror invalidation as attachTransectTables — the packed
+    // mirrors would otherwise serve stale (cheb-less) copies.
+    packed_groups_.clear();
+    packed_count_.clear();
+    mask_active_ = false;
+    for (auto& g : groups_) {
+        // Every POLYGON group needs this; any other group needs it too once
+        // XSECT_GEOMETRY EXACT compiled a boundary for its shape (a link with
+        // no compiled boundary simply keeps a null cheb entry, which routes
+        // it back through that group's normal table/formula kernels).
+        bool any = false;
+        for (int k = 0; k < g.count && !any; ++k) {
+            int link_j = g.link_idx[static_cast<std::size_t>(k)];
+            if (ctx.links.xsect_cheb_idx[static_cast<std::size_t>(link_j)] >= 0) any = true;
+        }
+        if (!any || g.count == 0) continue;
+
+        auto uc = static_cast<std::size_t>(g.count);
+        g.cheb.resize(uc, nullptr);
+
+        for (int k = 0; k < g.count; ++k) {
+            auto uk = static_cast<std::size_t>(k);
+            int link_j = g.link_idx[uk];
+            auto uj = static_cast<std::size_t>(link_j);
+
+            int ci = ctx.links.xsect_cheb_idx[uj];
+            if (ci >= 0 && static_cast<std::size_t>(ci) < ctx.cheb_sections.size()) {
+                // Same stability argument as attachTransectTables: a raw
+                // pointer into ctx.cheb_sections, valid because it is a
+                // std::deque (stable addresses across push_back) and nothing
+                // appends to it once BUILDING/OPENED is left.
+                const auto& cs = ctx.cheb_sections[static_cast<std::size_t>(ci)];
+                g.cheb[uk] = &cs;
+                g.y_full[uk] = cs.y_full;
+                g.inv_y_full[uk] = (cs.y_full > 0.0) ? 1.0 / cs.y_full : 0.0;
+                g.a_full[uk] = cs.a_full;
+                g.r_full[uk] = cs.r_full;
+                g.s_full[uk] = cs.s_full;
+                g.w_max[uk]  = cs.w_max;
             }
         }
     }
@@ -709,7 +757,32 @@ static inline XSectParams paramsAt(const ShapeGroup& g, int k) {
     xs.a_bot  = g.a_bot[uk];
     xs.s_bot  = g.s_bot[uk];
     xs.r_bot  = g.r_bot[uk];
+    if (uk < g.cheb.size()) xs.cheb = g.cheb[uk];
     return xs;
+}
+
+/// R = A/P via chebsec::chebAll's ONE shared-basis pass, instead of
+/// xsect::getRofY's chebRofY (which independently re-walks the piece lookup
+/// and Clenshaw recurrence once for A and again for P). W/I1 fall out of the
+/// same pass and are discarded — still cheaper than two independent
+/// evaluations, since the basis terms are shared across all four fields.
+static inline double cheb_getRofY_fast(const chebsec::ChebSection& cs, double y) {
+    double a, w, p, i1;
+    chebsec::chebAll(cs, y, &a, &w, &p, &i1);
+    return (p > 0.0) ? a / p : 0.0;
+}
+
+/// A and R together via ONE chebAll pass — the fused counterpart to
+/// area_hydrad_circular for a compiled boundary. Calling apply_area_kernel
+/// then apply_hydrad_kernel back to back would walk the same piece/Clenshaw
+/// three times over (A once for area, then A again and P once for hydrad);
+/// this walks it once.
+static inline void cheb_getAofY_getRofY_fast(const chebsec::ChebSection& cs, double y,
+                                             double& a_out, double& r_out) {
+    double a, w, p, i1;
+    chebsec::chebAll(cs, y, &a, &w, &p, &i1);
+    a_out = a;
+    r_out = (p > 0.0) ? a / p : 0.0;
 }
 
 /// Get the area lookup table and size for a tabulated shape.
@@ -790,8 +863,21 @@ static void apply_area_kernel(const ShapeGroup& g,
     switch (g.shape) {
         case XSectShape::CIRCULAR:
         case XSectShape::FORCE_MAIN:
-            xsect_batch::area_circular(ld, norm_param(g) + lo,
-                                       g.a_full.data() + lo, la, n);
+            // g.cheb is non-empty only once some member of this group has a
+            // compiled EXACT boundary (attachChebSections); the legacy
+            // circular table kernel below knows nothing about xs.cheb, so it
+            // must be bypassed in favor of the cheb-aware scalar path, which
+            // is correct per element (paramsAt forwards g.cheb[uk], null or
+            // not) even for a group with a mix of compiled/uncompiled links.
+            if (!g.cheb.empty()) {
+                for (int k = lo; k < lo + n; ++k) {
+                    auto uk = static_cast<std::size_t>(k);
+                    local_a[uk] = xsect::getAofY(paramsAt(g, k), local_d[uk]);
+                }
+            } else {
+                xsect_batch::area_circular(ld, norm_param(g) + lo,
+                                           g.a_full.data() + lo, la, n);
+            }
             break;
         case XSectShape::RECT_CLOSED:
         case XSectShape::RECT_OPEN:
@@ -861,8 +947,20 @@ static void apply_hydrad_kernel(const ShapeGroup& g,
     switch (g.shape) {
         case XSectShape::CIRCULAR:
         case XSectShape::FORCE_MAIN:
-            xsect_batch::hydrad_circular(ld, norm_param(g) + lo,
-                                         g.r_full.data() + lo, lh, n);
+            // See apply_area_kernel — g.cheb non-empty means at least one
+            // member compiled an EXACT boundary, which the legacy table
+            // kernel below cannot see; the scalar path is cheb-aware.
+            if (!g.cheb.empty()) {
+                for (int k = lo; k < lo + n; ++k) {
+                    auto uk = static_cast<std::size_t>(k);
+                    local_h[uk] = g.cheb[uk]
+                        ? cheb_getRofY_fast(*g.cheb[uk], local_d[uk])
+                        : xsect::getRofY(paramsAt(g, k), local_d[uk]);
+                }
+            } else {
+                xsect_batch::hydrad_circular(ld, norm_param(g) + lo,
+                                             g.r_full.data() + lo, lh, n);
+            }
             break;
         case XSectShape::RECT_CLOSED:
             xsect_batch::hydrad_rect_closed(ld, g.w_max.data() + lo,
@@ -897,9 +995,16 @@ static void apply_hydrad_kernel(const ShapeGroup& g,
                                               g.r_full.data() + lo, tbl.data, tbl.size,
                                               lh, n);
             } else {
+                // POLYGON (always) and any other shape reconstructed under
+                // XSECT_GEOMETRY EXACT land here — no legacy table exists at
+                // all, so g.cheb[uk] is set whenever the boundary compiled.
+                // See cheb_getRofY_fast: one shared chebAll pass, not
+                // getRofY's independent chebAofY + chebPofY.
                 for (int k = lo; k < lo + n; ++k) {
                     auto uk = static_cast<std::size_t>(k);
-                    local_h[uk] = xsect::getRofY(paramsAt(g, k), local_d[uk]);
+                    local_h[uk] = (uk < g.cheb.size() && g.cheb[uk])
+                        ? cheb_getRofY_fast(*g.cheb[uk], local_d[uk])
+                        : xsect::getRofY(paramsAt(g, k), local_d[uk]);
                 }
             }
             break;
@@ -922,8 +1027,18 @@ static void apply_width_kernel(const ShapeGroup& g,
     switch (g.shape) {
         case XSectShape::CIRCULAR:
         case XSectShape::FORCE_MAIN:
-            xsect_batch::width_circular(ld, norm_param(g) + lo,
-                                        g.w_max.data() + lo, lw, n);
+            // See apply_area_kernel — g.cheb non-empty means at least one
+            // member compiled an EXACT boundary, which the legacy table
+            // kernel below cannot see; the scalar path is cheb-aware.
+            if (!g.cheb.empty()) {
+                for (int k = lo; k < lo + n; ++k) {
+                    auto uk = static_cast<std::size_t>(k);
+                    local_w[uk] = xsect::getWofY(paramsAt(g, k), local_d[uk]);
+                }
+            } else {
+                xsect_batch::width_circular(ld, norm_param(g) + lo,
+                                            g.w_max.data() + lo, lw, n);
+            }
             break;
         case XSectShape::RECT_OPEN:
             xsect_batch::width_rect(g.w_max.data() + lo, lw, n);
@@ -971,14 +1086,32 @@ static void apply_width_kernel(const ShapeGroup& g,
     apply_width_kernel(g, local_d, local_w, 0, g.count);
 }
 
-// Combined area + hydraulic radius over one group (single depth gather). Uses
-// the fused circular kernel for the dominant CIRCULAR/FORCE_MAIN shape (shares
-// the table index between A and R); falls back to the two separate dispatchers
-// for every other shape. Range form — see apply_area_kernel.
+// Combined area + hydraulic radius over one group (single depth gather). A
+// cheb-backed group (POLYGON always; any shape under XSECT_GEOMETRY EXACT)
+// takes a dedicated fused branch — one chebAll pass yields A and P together,
+// so R = A/P is free, versus calling apply_area_kernel then apply_hydrad_kernel
+// separately, which would independently re-walk the same piece/Clenshaw three
+// times (once for area, then again for area and once more for perimeter
+// inside getRofY's chebRofY). Falls back to the fused circular table kernel
+// for the dominant CIRCULAR/FORCE_MAIN LEGACY-mode shape (shares the table
+// index between A and R), or the two separate dispatchers for every other
+// shape. Range form — see apply_area_kernel.
 static void apply_area_hydrad_kernel(const ShapeGroup& g, const double* local_d,
                                      double* local_a, double* local_h,
                                      int lo, int n) {
-    if (g.shape == XSectShape::CIRCULAR || g.shape == XSectShape::FORCE_MAIN) {
+    if (!g.cheb.empty()) {
+        for (int k = lo; k < lo + n; ++k) {
+            auto uk = static_cast<std::size_t>(k);
+            if (g.cheb[uk]) {
+                cheb_getAofY_getRofY_fast(*g.cheb[uk], local_d[uk],
+                                          local_a[uk], local_h[uk]);
+            } else {
+                const XSectParams xs = paramsAt(g, k);
+                local_a[uk] = xsect::getAofY(xs, local_d[uk]);
+                local_h[uk] = xsect::getRofY(xs, local_d[uk]);
+            }
+        }
+    } else if (g.shape == XSectShape::CIRCULAR || g.shape == XSectShape::FORCE_MAIN) {
         xsect_batch::area_hydrad_circular(local_d + lo, norm_param(g) + lo,
                                           g.a_full.data() + lo, g.r_full.data() + lo,
                                           local_a + lo, local_h + lo, n);

--- a/src/engine/hydraulics/XSectBatch.cpp
+++ b/src/engine/hydraulics/XSectBatch.cpp
@@ -909,6 +909,21 @@ static void apply_area_kernel(const ShapeGroup& g,
                                                g.transect_tbl_size, la, n);
             break;
         default: {
+            // g.cheb must be checked BEFORE either table lookup: EGG/
+            // HORSESHOE/BASKETHANDLE/HORIZ_ELLIPSE/VERT_ELLIPSE/ARCH have
+            // real area_table_for data, and GOTHIC/CATENARY/SEMIELLIPTICAL/
+            // SEMICIRCULAR have real area_inv_table_for data, so EVERY
+            // tabulated shape EXACT reconstructs would otherwise take its
+            // legacy table unconditionally and never reach the scalar
+            // cheb-aware path below — the same bypass already fixed for
+            // CIRCULAR/FORCE_MAIN above, just reached from the other arm.
+            if (!g.cheb.empty()) {
+                for (int k = lo; k < lo + n; ++k) {
+                    auto uk = static_cast<std::size_t>(k);
+                    local_a[uk] = xsect::getAofY(paramsAt(g, k), local_d[uk]);
+                }
+                break;
+            }
             auto tbl = area_table_for(g.shape);
             if (tbl.data) {
                 xsect_batch::area_tabulated(ld, norm_param(g) + lo,
@@ -989,22 +1004,31 @@ static void apply_hydrad_kernel(const ShapeGroup& g,
                                                g.transect_tbl_size, lh, n);
             break;
         default: {
+            // g.cheb must be checked BEFORE the table lookup: EGG/HORSESHOE/
+            // BASKETHANDLE/HORIZ_ELLIPSE/VERT_ELLIPSE/ARCH have real
+            // hydrad_table_for data too, so those would otherwise take their
+            // legacy table unconditionally and never reach the cheb-aware
+            // path below, exactly like the CIRCULAR bypass fixed above (only
+            // GOTHIC/CATENARY/SEMIELLIPTICAL/SEMICIRCULAR/POLYGON have no
+            // table at all, so this used to look sufficient — it was not).
+            if (!g.cheb.empty()) {
+                for (int k = lo; k < lo + n; ++k) {
+                    auto uk = static_cast<std::size_t>(k);
+                    local_h[uk] = g.cheb[uk]
+                        ? cheb_getRofY_fast(*g.cheb[uk], local_d[uk])
+                        : xsect::getRofY(paramsAt(g, k), local_d[uk]);
+                }
+                break;
+            }
             auto tbl = hydrad_table_for(g.shape);
             if (tbl.data) {
                 xsect_batch::hydrad_tabulated(ld, norm_param(g) + lo,
                                               g.r_full.data() + lo, tbl.data, tbl.size,
                                               lh, n);
             } else {
-                // POLYGON (always) and any other shape reconstructed under
-                // XSECT_GEOMETRY EXACT land here — no legacy table exists at
-                // all, so g.cheb[uk] is set whenever the boundary compiled.
-                // See cheb_getRofY_fast: one shared chebAll pass, not
-                // getRofY's independent chebAofY + chebPofY.
                 for (int k = lo; k < lo + n; ++k) {
                     auto uk = static_cast<std::size_t>(k);
-                    local_h[uk] = (uk < g.cheb.size() && g.cheb[uk])
-                        ? cheb_getRofY_fast(*g.cheb[uk], local_d[uk])
-                        : xsect::getRofY(paramsAt(g, k), local_d[uk]);
+                    local_h[uk] = xsect::getRofY(paramsAt(g, k), local_d[uk]);
                 }
             }
             break;
@@ -1065,6 +1089,18 @@ static void apply_width_kernel(const ShapeGroup& g,
                                                g.transect_tbl_size, lw, n);
             break;
         default: {
+            // g.cheb must be checked BEFORE the table lookup — ALL 10
+            // tabulated shapes have real width_table_for data, so this would
+            // otherwise take the legacy table unconditionally for every one
+            // of them and never reach the cheb-aware path below. Same bypass
+            // as area/hydrad above.
+            if (!g.cheb.empty()) {
+                for (int k = lo; k < lo + n; ++k) {
+                    auto uk = static_cast<std::size_t>(k);
+                    local_w[uk] = xsect::getWofY(paramsAt(g, k), local_d[uk]);
+                }
+                break;
+            }
             auto tbl = width_table_for(g.shape);
             if (tbl.data) {
                 xsect_batch::width_tabulated(ld, norm_param(g) + lo,

--- a/src/engine/hydraulics/XSectBatch.hpp
+++ b/src/engine/hydraulics/XSectBatch.hpp
@@ -68,6 +68,8 @@ namespace openswmm {
 // Forward declaration
 struct SimulationContext;
 
+namespace chebsec { struct ChebSection; }
+
 // ============================================================================
 // Cross-section shape codes (matches legacy enums.h XsectType)
 // ============================================================================
@@ -98,7 +100,8 @@ enum class XSectShape : int {
     IRREGULAR          = 22,
     CUSTOM             = 23,
     FORCE_MAIN         = 24,
-    STREET_XSECT       = 25
+    STREET_XSECT       = 25,
+    POLYGON            = 26
 };
 
 // ============================================================================
@@ -133,6 +136,14 @@ struct XSectParams {
     const double* hrad_tbl  = nullptr;   ///< Normalized hyd-radius vs y/y_full
     const double* width_tbl = nullptr;   ///< Normalized width     vs y/y_full
     int    transect_tbl_size = 0;        ///< Entry count of the tables above
+
+    // Piecewise-Chebyshev boundary (POLYGON shapes ALWAYS; other shapes only
+    // under `[OPTIONS] XSECT_GEOMETRY EXACT`). When non-null, every accessor
+    // in XsectEval takes this path instead of its per-shape table/formula
+    // dispatch, regardless of @ref type — see the `xs.cheb` early-return at
+    // the top of each dispatcher in XSectKernels.hpp. Points into
+    // ctx.cheb_sections (a std::deque, so the address is stable for the run).
+    const chebsec::ChebSection* cheb = nullptr;
 };
 
 // ============================================================================
@@ -152,6 +163,12 @@ double getAofS(const XSectParams& xs, double s_factor);
 double getAmax(const XSectParams& xs);
 double getYcrit(const XSectParams& xs, double q);
 bool   isOpen(int type);
+/// Per-instance open/closed test. A POLYGON section (or any shape whose
+/// XSectParams::cheb is set under XSECT_GEOMETRY EXACT) cannot be classified
+/// from its shape code alone — open vs. closed is a property of the specific
+/// compiled boundary, recorded in ChebSection::is_open. Falls back to
+/// isOpen(int) for shapes with no compiled boundary.
+bool   isOpen(const XSectParams& xs);
 int    setParams(XSectParams& xs, int type, const double p[], double ucf);
 
 // Lookup table helpers (exposed for batch kernels and testing)
@@ -207,6 +224,12 @@ struct ShapeGroup {
     std::vector<const double*> width_tables;  ///< Per-link width table
     int transect_tbl_size = 0;                ///< Table size (same for all)
 
+    // Per-link compiled Chebyshev boundary (POLYGON group always; other
+    // groups only under XSECT_GEOMETRY EXACT — see attachChebSections()).
+    // Non-null entries here are what make the scalar per-element fallback
+    // (paramsAt()) route through the exact/Chebyshev path.
+    std::vector<const chebsec::ChebSection*> cheb;
+
     // Pre-allocated working buffers (avoids per-call allocation in hot loop)
     mutable std::vector<double> buf_d;   ///< Gather buffer for depths
     mutable std::vector<double> buf_r;   ///< Scatter buffer for results
@@ -255,6 +278,20 @@ public:
      * @param ctx  SimulationContext with transect_tables populated.
      */
     void attachTransectTables(const SimulationContext& ctx);
+
+    /**
+     * @brief Attach compiled Chebyshev boundaries to POLYGON (and, under
+     *        XSECT_GEOMETRY EXACT, any other) shape groups.
+     *
+     * @details Must be called after build() when POLYGON shapes exist, or
+     *          when EXACT mode compiled built-in shapes too. Mirrors
+     *          attachTransectTables() exactly, one array (cheb) instead of
+     *          three, keyed by LinkData::xsect_cheb_idx instead of
+     *          xsect_curve.
+     *
+     * @param ctx  SimulationContext with cheb_sections populated.
+     */
+    void attachChebSections(const SimulationContext& ctx);
 
     /**
      * @brief Build shape groups from an array of XSectParams.

--- a/src/engine/hydraulics/XSectKernels.hpp
+++ b/src/engine/hydraulics/XSectKernels.hpp
@@ -1470,7 +1470,7 @@ struct XsectEval {
             double y1 = 0.0;
             double y2 = 0.99 * xs.y_full;
             double q2 = qCritical(y2, 0.0);
-            if (q2 < q) return std::min(xs.y_full, xs.y_full);
+            if (q2 < q) return xs.y_full;
             double q0 = qCritical(y0, 0.0);
             double q1 = qCritical(0.5 * xs.y_full, 0.0);
             if (q0 > q) {

--- a/src/engine/hydraulics/XSectKernels.hpp
+++ b/src/engine/hydraulics/XSectKernels.hpp
@@ -62,6 +62,7 @@
 #include <cmath>
 
 #include "XSectLookup.hpp"
+#include "ChebSection.hpp"
 #include "../data/LinkData.hpp"
 
 // Portable kernel-function marker — same convention as FvKernels.hpp and
@@ -539,6 +540,23 @@ struct XsectEval {
         return dSdA * xs.s_full / xs.a_full;
     }
 
+    // S(A) = A * R^(2/3), so dS/dA = R^(2/3) + (2/3)*A*R^(-1/3)*dR/dA — algebraically
+    // the same closed form circ_getdSdA uses below (expand and it reduces to
+    // (5/3 - (2/3)*dPdA*R) * R^(2/3)), just reached via the chain rule instead of
+    // a direct dP/dA formula: dR/dA = 1/P - (A/P^2)*dP/dA, dP/dA = (dP/dy)/(dA/dy).
+    // Exact throughout — chebdAdY and chebdPdY are the fit's own derivative
+    // coefficients, not finite differences.
+    OPENSWMM_KERNEL_FN double cheb_getdSdA(const XSectParams& xs, double a) const {
+        if (a <= 0.0 || !xs.cheb) return 0.0;
+        const double y = chebsec::chebYofA(*xs.cheb, a);
+        const double w = chebsec::chebdAdY(*xs.cheb, y);   // dA/dy = W, exact
+        const double p = chebsec::chebPofY(*xs.cheb, y);
+        if (w <= 0.0 || p <= 0.0) return generic_getdSdA(xs, a);
+        const double r = a / p;
+        const double dPdA = chebsec::chebdPdY(*xs.cheb, y) / w;
+        return (5.0 / 3.0 - (2.0 / 3.0) * dPdA * r) * std::pow(r, 2.0 / 3.0);
+    }
+
     // ============================================================================
     // Circular
     // ============================================================================
@@ -981,6 +999,11 @@ struct XsectEval {
     // ============================================================================
 
     OPENSWMM_KERNEL_FN double getAofY(const XSectParams& xs, double y) const {
+        // A compiled Chebyshev boundary takes over ALL evaluation for this
+        // section regardless of xs.type — set unconditionally for POLYGON,
+        // and for any other shape once XSECT_GEOMETRY EXACT compiles it too.
+        // Every dispatcher below carries this same early return.
+        if (xs.cheb) return chebsec::chebAofY(*xs.cheb, y);
         if (y <= 0.0) return 0.0;
         // A section with no (or not-yet-set) full depth has no area. Guard the
         // division so a degenerate cross-section — e.g. a conduit finalized before
@@ -1038,6 +1061,7 @@ struct XsectEval {
     // ============================================================================
 
     OPENSWMM_KERNEL_FN double getWofY(const XSectParams& xs, double y) const {
+        if (xs.cheb) return chebsec::chebWofY(*xs.cheb, y);
         double y_norm = y / xs.y_full;
 
         switch (static_cast<XSectShape>(xs.type)) {
@@ -1094,6 +1118,7 @@ struct XsectEval {
     // ============================================================================
 
     OPENSWMM_KERNEL_FN double getRofY(const XSectParams& xs, double y) const {
+        if (xs.cheb) return chebsec::chebRofY(*xs.cheb, y);
         double y_norm = y / xs.y_full;
 
         switch (static_cast<XSectShape>(xs.type)) {
@@ -1141,6 +1166,7 @@ struct XsectEval {
     // ============================================================================
 
     OPENSWMM_KERNEL_FN double getYofA(const XSectParams& xs, double a) const {
+        if (xs.cheb) return chebsec::chebYofA(*xs.cheb, a);
         if (a <= 0.0) return 0.0;
         double alpha = a / xs.a_full;
 
@@ -1193,6 +1219,16 @@ struct XsectEval {
     // ============================================================================
 
     OPENSWMM_KERNEL_FN double getSofA(const XSectParams& xs, double a) const {
+        if (xs.cheb) {
+            // Same generic S = A*R^(2/3) formula the switch's own default:
+            // branch below uses — forced here because several shapes ahead
+            // of default: (CIRCULAR, EGGSHAPED, ...) have explicit
+            // table-lookup cases that would otherwise intercept first.
+            if (a == 0.0) return 0.0;
+            double r = getRofA(xs, a);   // redirects through xs.cheb itself
+            if (r < TINY) return 0.0;
+            return a * std::pow(r, 2.0 / 3.0);
+        }
         double alpha = a / xs.a_full;
 
         switch (static_cast<XSectShape>(xs.type)) {
@@ -1231,6 +1267,7 @@ struct XsectEval {
 
     OPENSWMM_KERNEL_FN double getRofA(const XSectParams& xs, double a) const {
         if (a <= 0.0) return 0.0;
+        if (xs.cheb) return chebsec::chebRofY(*xs.cheb, chebsec::chebYofA(*xs.cheb, a));
         switch (static_cast<XSectShape>(xs.type)) {
             case XSectShape::HORIZ_ELLIPSE:
             case XSectShape::VERT_ELLIPSE:
@@ -1263,6 +1300,7 @@ struct XsectEval {
     // ============================================================================
 
     OPENSWMM_KERNEL_FN double getdSdA(const XSectParams& xs, double a) const {
+        if (xs.cheb) return cheb_getdSdA(xs, a);
         switch (static_cast<XSectShape>(xs.type)) {
             case XSectShape::FORCE_MAIN:
             case XSectShape::CIRCULAR:     return circ_getdSdA(xs, a);
@@ -1295,10 +1333,40 @@ struct XsectEval {
     // getAofS — area from section factor
     // ============================================================================
 
+    // Newton-Raphson on S(a) = s, bracketed in [a1, a2] (legacy generic_getAofS).
+    // a2 = absolute area at max flow. PARITY: legacy xsect_getAmax (xsect.c:
+    // 711-713) returns aBot for BOTH IRREGULAR and CUSTOM (the physical area
+    // at the max section factor, set from the transect/shape tables); every
+    // other shape uses aFull * Amax-ratio. A compiled Chebyshev boundary
+    // (xs.cheb) always has an absolute a_max of its own — see getAmax, which
+    // returns it pre-divided back to the ratio this formula expects.
+    OPENSWMM_KERNEL_FN double generic_getAofS(const XSectParams& xs, double s) const {
+        double a1, a2;
+        const XSectShape sh = static_cast<XSectShape>(xs.type);
+        double a_max = (!xs.cheb && (sh == XSectShape::CUSTOM || sh == XSectShape::IRREGULAR))
+                           ? xs.a_bot
+                           : xs.a_full * getAmax(xs);
+        if ((s <= xs.s_max && s >= xs.s_full) && xs.s_max != xs.s_full) {
+            a1 = xs.a_full;   // sFull < sMax: root lies between aFull and aMax
+            a2 = a_max;
+        } else {
+            a1 = 0.0;
+            a2 = a_max;
+        }
+        double a = 0.5 * (a1 + a2);
+        double tol = 0.0001 * xs.a_full;
+        findroot_Newton(a1, a2, &a, tol, [&](double aa, double* f, double* df) {
+            *f = getSofA(xs, aa) - s;
+            *df = getdSdA(xs, aa);
+        });
+        return a;
+    }
+
     OPENSWMM_KERNEL_FN double getAofS(const XSectParams& xs, double s) const {
         double psi = s / xs.s_full;
         if (s <= 0.0) return 0.0;
         if (s > xs.s_max) s = xs.s_max;
+        if (xs.cheb) return generic_getAofS(xs, s);
 
         switch (static_cast<XSectShape>(xs.type)) {
             case XSectShape::DUMMY: return 0.0;
@@ -1318,33 +1386,8 @@ struct XsectEval {
                 return xs.a_full * invLookup(psi, tbl.S_BasketHandle, tbl.N_S_BasketHandle);
             case XSectShape::SEMICIRCULAR:
                 return xs.a_full * invLookup(psi, tbl.S_SemiCirc, tbl.N_S_SemiCirc);
-            default: {
-                // Newton-Raphson on S(a) = s, bracketed in [a1, a2] (legacy generic_getAofS).
-                // a2 = absolute area at max flow = xsect_getAmax.
-                // PARITY: legacy xsect_getAmax (xsect.c:711-713) returns aBot for
-                // BOTH IRREGULAR and CUSTOM (the physical area at the max section
-                // factor, set from the transect/shape tables); every other shape
-                // uses aFull * Amax-ratio.
-                double a1, a2;
-                const XSectShape sh = static_cast<XSectShape>(xs.type);
-                double a_max = (sh == XSectShape::CUSTOM || sh == XSectShape::IRREGULAR)
-                                   ? xs.a_bot
-                                   : xs.a_full * getAmax(xs);
-                if ((s <= xs.s_max && s >= xs.s_full) && xs.s_max != xs.s_full) {
-                    a1 = xs.a_full;   // sFull < sMax: root lies between aFull and aMax
-                    a2 = a_max;
-                } else {
-                    a1 = 0.0;
-                    a2 = a_max;
-                }
-                double a = 0.5 * (a1 + a2);
-                double tol = 0.0001 * xs.a_full;
-                findroot_Newton(a1, a2, &a, tol, [&](double aa, double* f, double* df) {
-                    *f = getSofA(xs, aa) - s;
-                    *df = getdSdA(xs, aa);
-                });
-                return a;
-            }
+            default:
+                return generic_getAofS(xs, s);
         }
     }
 
@@ -1353,6 +1396,16 @@ struct XsectEval {
     // ============================================================================
 
     OPENSWMM_KERNEL_FN double getAmax(const XSectParams& xs) const {
+        if (xs.cheb) {
+            // Unlike every tabulated shape, a compiled boundary's max-flow
+            // area is not a fixed ratio constant — it is measured per-
+            // instance by chebsec::compile() and stored as an ABSOLUTE area
+            // (ChebSection::a_max), mirroring how CUSTOM/IRREGULAR store an
+            // absolute xs.a_bot. Divide back to the ratio every caller of
+            // this function expects (they all multiply by xs.a_full).
+            if (xs.a_full <= 0.0) return 1.0;
+            return xs.cheb->a_max / xs.a_full;
+        }
         if (xs.type >= 0 && xs.type <= 25)
             return tbl.Amax[xs.type];
         return 1.0;
@@ -1362,10 +1415,82 @@ struct XsectEval {
     // getYcrit — critical depth for a given flow rate (legacy xsect_getYcrit)
     // ============================================================================
 
+    // Critical-depth solve shared by every shape with no closed-form Ycrit
+    // formula (legacy getYcritEnum/getYcritRidder) — extracted so a compiled
+    // Chebyshev boundary (xs.cheb) can force this path too, rather than a
+    // shape whose boundary is only an APPROXIMATION of its legacy closed-form
+    // curve (e.g. PARABOLIC/POWERFUNC reconstructed as a dense polyline under
+    // XSECT_GEOMETRY EXACT) mixing an exact formula with an approximate A/W.
+    OPENSWMM_KERNEL_FN double generic_getYcrit(const XSectParams& xs, double q, double q2g) const {
+        // Critical flow function Q_c(yc) - qTarget (legacy getQcritical).
+        auto qCritical = [&](double yc, double qTarget) -> double {
+            double a = getAofY(xs, yc);
+            double w = getWofY(xs, yc);
+            if (w > 0.0) return a * std::sqrt(GRAVITY * a / w) - qTarget;
+            return -qTarget;
+        };
+
+        // Initial estimate from equivalent circular conduit.
+        double y0 = 1.01 * std::pow(q2g / xs.y_full, 0.25);
+        if (y0 >= xs.y_full) y0 = 0.97 * xs.y_full;
+
+        // Ratio of conduit area to equivalent circular area.
+        double r = xs.a_full / (PI / 4.0 * xs.y_full * xs.y_full);
+
+        double y;
+        if (r >= 0.5 && r <= 2.0) {
+            // --- interval enumeration (legacy getYcritEnum), 25 increments
+            constexpr int N_INC = 25;
+            double dy = xs.y_full / N_INC;
+            int i1 = static_cast<int>(y0 / dy);
+            double q0 = qCritical(i1 * dy, 0.0);
+            if (q0 < q) {
+                y = xs.y_full;
+                for (int i = i1 + 1; i <= N_INC; ++i) {
+                    double qc = qCritical(i * dy, 0.0);
+                    if (qc >= q) {
+                        y = ((q - q0) / (qc - q0) + static_cast<double>(i - 1)) * dy;
+                        break;
+                    }
+                    q0 = qc;
+                }
+            } else {
+                y = 0.0;
+                for (int i = i1 - 1; i >= 0; --i) {
+                    double qc = qCritical(i * dy, 0.0);
+                    if (qc < q) {
+                        y = ((q - qc) / (q0 - qc) + static_cast<double>(i)) * dy;
+                        break;
+                    }
+                    q0 = qc;
+                }
+            }
+        } else {
+            // --- Ridder's method (legacy getYcritRidder)
+            double y1 = 0.0;
+            double y2 = 0.99 * xs.y_full;
+            double q2 = qCritical(y2, 0.0);
+            if (q2 < q) return std::min(xs.y_full, xs.y_full);
+            double q0 = qCritical(y0, 0.0);
+            double q1 = qCritical(0.5 * xs.y_full, 0.0);
+            if (q0 > q) {
+                y2 = y0;
+                if (q1 < q) y1 = 0.5 * xs.y_full;
+            } else {
+                y1 = y0;
+                if (q1 > q) y2 = 0.5 * xs.y_full;
+            }
+            y = findroot_Ridder(y1, y2, 0.001,
+                                [&](double yc) { return qCritical(yc, q); });
+        }
+        return std::min(y, xs.y_full);
+    }
+
     OPENSWMM_KERNEL_FN double getYcrit(const XSectParams& xs, double q) const {
         if (q <= 0.0) return 0.0;
         double q2g = q * q / GRAVITY;
         if (q2g == 0.0) return 0.0;
+        if (xs.cheb) return generic_getYcrit(xs, q, q2g);
 
         double y;
         switch (static_cast<XSectShape>(xs.type)) {
@@ -1384,69 +1509,8 @@ struct XsectEval {
                 y = 1.0 / (2.0 * xs.s_bot + 3.0);
                 y = std::pow(q2g * (xs.s_bot + 1.0) / (xs.r_bot * xs.r_bot), y);
                 break;
-            default: {
-                // Critical flow function Q_c(yc) - qTarget (legacy getQcritical).
-                auto qCritical = [&](double yc, double qTarget) -> double {
-                    double a = getAofY(xs, yc);
-                    double w = getWofY(xs, yc);
-                    if (w > 0.0) return a * std::sqrt(GRAVITY * a / w) - qTarget;
-                    return -qTarget;
-                };
-
-                // Initial estimate from equivalent circular conduit.
-                double y0 = 1.01 * std::pow(q2g / xs.y_full, 0.25);
-                if (y0 >= xs.y_full) y0 = 0.97 * xs.y_full;
-
-                // Ratio of conduit area to equivalent circular area.
-                double r = xs.a_full / (PI / 4.0 * xs.y_full * xs.y_full);
-
-                if (r >= 0.5 && r <= 2.0) {
-                    // --- interval enumeration (legacy getYcritEnum), 25 increments
-                    constexpr int N_INC = 25;
-                    double dy = xs.y_full / N_INC;
-                    int i1 = static_cast<int>(y0 / dy);
-                    double q0 = qCritical(i1 * dy, 0.0);
-                    if (q0 < q) {
-                        y = xs.y_full;
-                        for (int i = i1 + 1; i <= N_INC; ++i) {
-                            double qc = qCritical(i * dy, 0.0);
-                            if (qc >= q) {
-                                y = ((q - q0) / (qc - q0) + static_cast<double>(i - 1)) * dy;
-                                break;
-                            }
-                            q0 = qc;
-                        }
-                    } else {
-                        y = 0.0;
-                        for (int i = i1 - 1; i >= 0; --i) {
-                            double qc = qCritical(i * dy, 0.0);
-                            if (qc < q) {
-                                y = ((q - qc) / (q0 - qc) + static_cast<double>(i)) * dy;
-                                break;
-                            }
-                            q0 = qc;
-                        }
-                    }
-                } else {
-                    // --- Ridder's method (legacy getYcritRidder)
-                    double y1 = 0.0;
-                    double y2 = 0.99 * xs.y_full;
-                    double q2 = qCritical(y2, 0.0);
-                    if (q2 < q) { y = xs.y_full; break; }
-                    double q0 = qCritical(y0, 0.0);
-                    double q1 = qCritical(0.5 * xs.y_full, 0.0);
-                    if (q0 > q) {
-                        y2 = y0;
-                        if (q1 < q) y1 = 0.5 * xs.y_full;
-                    } else {
-                        y1 = y0;
-                        if (q1 > q) y2 = 0.5 * xs.y_full;
-                    }
-                    y = findroot_Ridder(y1, y2, 0.001,
-                                        [&](double yc) { return qCritical(yc, q); });
-                }
-                break;
-            }
+            default:
+                return generic_getYcrit(xs, q, q2g);
         }
         return std::min(y, xs.y_full);
     }
@@ -1467,6 +1531,17 @@ struct XsectEval {
             default:
                 return false;
         }
+    }
+
+    /// Per-instance open/closed test — see the declaration in XSectBatch.hpp.
+    /// A compiled boundary's own ChebSection::is_open is authoritative
+    /// (POLYGON has no shape code that isOpen(int) could classify at all,
+    /// and RECT_OPEN/etc. under XSECT_GEOMETRY EXACT still resolve correctly
+    /// here because their boundary was compiled with the SAME is_open value
+    /// isOpen(int) would have returned — see PostParseResolver).
+    OPENSWMM_KERNEL_FN bool isOpen(const XSectParams& xs) const {
+        if (xs.cheb) return xs.cheb->is_open;
+        return isOpen(xs.type);
     }
 
 };

--- a/src/engine/hydraulics/XSection.cpp
+++ b/src/engine/hydraulics/XSection.cpp
@@ -192,6 +192,7 @@ double getAofS(const XSectParams& xs, double s)  { return hostEval().getAofS(xs,
 double getAmax(const XSectParams& xs)            { return hostEval().getAmax(xs); }
 double getYcrit(const XSectParams& xs, double q) { return hostEval().getYcrit(xs, q); }
 bool   isOpen(int type)                          { return hostEval().isOpen(type); }
+bool   isOpen(const XSectParams& xs)             { return hostEval().isOpen(xs); }
 
 
 // ============================================================================
@@ -503,8 +504,9 @@ int setParams(XSectParams& xs, int type, const double p[], double ucf) {
         }
 
         default:
-            // IRREGULAR / CUSTOM / STREET_XSECT / DUMMY — geometry comes from
-            // transect/curve/street tables resolved externally; leave fields.
+            // IRREGULAR / CUSTOM / STREET_XSECT / DUMMY / POLYGON — geometry
+            // comes from transect/curve/street/boundary tables resolved
+            // externally (PostParseResolver); leave fields untouched.
             break;
     }
     return 0;

--- a/src/engine/hydraulics/fv/NetworkMeshBuilder.cpp
+++ b/src/engine/hydraulics/fv/NetworkMeshBuilder.cpp
@@ -249,12 +249,19 @@ MeshBuildReport buildNetworkMesh(SimulationContext& ctx,
                                double, double, double, double, double, double,
                                double, double, double, double, double,
                                const double*, const double*, const double*,
+                               const void*,
                                int, int, bool>;
     const auto geom_key = [](const XSectParams& x, int barrels, bool is_open) {
+        // x.cheb must be part of the key: two links can share every scalar
+        // summary field above (y_full, a_full, w_max, ...) while pointing at
+        // different compiled boundaries — e.g. two POLYGON curves with the
+        // same envelope but a different profile — and without this, the
+        // second link would silently inherit the first's tabulated geometry.
         return GeomKey{x.type, x.culvert_code, x.transect,
                        x.y_full, x.w_max, x.yw_max, x.a_full, x.r_full,
                        x.s_full, x.s_max, x.y_bot, x.a_bot, x.s_bot, x.r_bot,
                        x.area_tbl, x.hrad_tbl, x.width_tbl,
+                       static_cast<const void*>(x.cheb),
                        x.transect_tbl_size, barrels, is_open};
     };
     std::map<GeomKey, int> geom_memo;   // key -> conduit row already tabulated
@@ -273,7 +280,8 @@ MeshBuildReport buildNetworkMesh(SimulationContext& ctx,
         const auto uj = static_cast<std::size_t>(j);
         mesh.conduit_link[ur] = j;
 
-        XSectParams xs = link::buildXSectParams(ctx.links, uj, &ctx.transect_tables);
+        XSectParams xs = link::buildXSectParams(ctx.links, uj, &ctx.transect_tables,
+                                                &ctx.cheb_sections);
         if (xs.y_full <= 0.0 || xs.a_full <= 0.0) {
             // A control volume needs a real section. DUMMY-shape conduits and
             // links whose geometry never resolved cannot be marched.
@@ -285,7 +293,7 @@ MeshBuildReport buildNetworkMesh(SimulationContext& ctx,
         }
 
         auto& g = mesh.geom[ur];
-        const bool is_open = xsect::isOpen(xs.type);
+        const bool is_open = xsect::isOpen(xs);
         if (const auto hit = geom_memo.find(geom_key(xs, CD.barrels[ur], is_open));
             hit != geom_memo.end()) {
             // Copy the already-tabulated geometry wholesale. The per-conduit
@@ -596,13 +604,19 @@ MeshBuildReport buildNetworkMesh(SimulationContext& ctx,
             const auto& a = mesh.geom[static_cast<std::size_t>(g0)];
             const auto& b = mesh.geom[static_cast<std::size_t>(g1)];
             // Only average like with like. Different shape types, transect
-            // tables (IRREGULAR/CUSTOM/STREET) and differing barrel counts have
-            // no meaningful average; those faces keep their own section, which
-            // is still well balanced (the C-property holds for ANY consistent
-            // choice) and merely first order in the step.
+            // tables (IRREGULAR/CUSTOM/STREET), compiled Chebyshev boundaries
+            // (POLYGON, or any shape under XSECT_GEOMETRY EXACT — two
+            // per-link boundaries can't be averaged into a third valid one,
+            // and the copy below only copies a.xs.cheb verbatim, which would
+            // silently make the "averaged" y_full/a_full/... below dead code
+            // since every accessor checks xs.cheb first) and differing barrel
+            // counts have no meaningful average; those faces keep their own
+            // section, which is still well balanced (the C-property holds for
+            // ANY consistent choice) and merely first order in the step.
             if (a.xs.type != b.xs.type || a.barrels != b.barrels ||
                 a.xs.transect >= 0 || b.xs.transect >= 0 ||
-                a.xs.area_tbl != nullptr || b.xs.area_tbl != nullptr)
+                a.xs.area_tbl != nullptr || b.xs.area_tbl != nullptr ||
+                a.xs.cheb != nullptr || b.xs.cheb != nullptr)
                 continue;
             const auto key = std::make_pair(std::min(g0, g1), std::max(g0, g1));
             int gf;
@@ -624,7 +638,7 @@ MeshBuildReport buildNetworkMesh(SimulationContext& ctx,
                 xs.s_bot  = mid(a.xs.s_bot,  xb.s_bot);
                 xs.r_bot  = mid(a.xs.r_bot,  xb.r_bot);
                 FvGeometry g{};
-                buildGeometry(xs, xsect::isOpen(xs.type), opts.slot_celerity, g,
+                buildGeometry(xs, xsect::isOpen(xs), opts.slot_celerity, g,
                               a.barrels);
                 // Friction/loss scalars are never read through the face
                 // section (faceSide uses only A, W and I₁ from it), but carry

--- a/src/engine/input/PostParseResolver.cpp
+++ b/src/engine/input/PostParseResolver.cpp
@@ -36,6 +36,7 @@
 #include "../core/UnitConversion.hpp"
 #include "../hydraulics/xsect_tables.hpp"
 #include "../hydraulics/XSectBatch.hpp"
+#include "../hydraulics/LegacyShapeBoundary.hpp"
 #include "../hydraulics/Link.hpp"
 #include "../hydraulics/Street.hpp"
 #include "../hydraulics/ForceMain.hpp"
@@ -54,6 +55,7 @@
 #include <map>
 #include <string>
 #include <system_error>
+#include <tuple>
 #include <unordered_map>
 #include <utility>
 
@@ -1775,6 +1777,87 @@ void resolve_cross_references(SimulationContext& ctx) {
         }
     }
 
+    // Resolve POLYGON shape curves — [CURVES] XPOLYGON arc/line boundaries,
+    // compiled to a piecewise-Chebyshev section (Phase 4/5). Mirrors the
+    // CUSTOM block above: memoized by (curve, scale) so every link sharing
+    // both a curve and a scale shares one compiled ChebSection, exactly like
+    // CUSTOM shares one TransectData per (curve, y_full).
+    {
+        int n_tables = static_cast<int>(ctx.tables.tables.size());
+        std::map<std::pair<int, double>, int> polygon_memo;
+        const int us = ucf::getUnitSystem(static_cast<int>(ctx.options.flow_units));
+        const double ucf_len = ucf::Ucf[ucf::LENGTH][static_cast<std::size_t>(us)];
+        for (int j = 0; j < n_links; ++j) {
+            auto uj = static_cast<std::size_t>(j);
+            if (ctx.links.xsect_shape[uj] != XsectShape::POLYGON) continue;
+
+            const auto& cname = ctx.links.pump_curve_name[uj];
+            if (cname.empty()) continue;
+
+            int ci = ctx.find_curve(cname);
+            if (ci < 0 || ci >= n_tables) continue;
+
+            // Geom1 = scale (raw, display length units — 0/unset means "no
+            // scale given", taken as 1.0 rather than collapsing the section
+            // to zero size). Geom2 = open-channel flag (0/1).
+            double scale = ctx.links.xsect_geom1[uj];
+            if (scale <= 0.0) scale = 1.0;
+            scale /= ucf_len;
+            const bool is_open = ctx.links.xsect_geom2[uj] != 0.0;
+
+            const auto memo = polygon_memo.find({ci, scale});
+            if (memo != polygon_memo.end()) {
+                const auto& shared = ctx.cheb_sections[static_cast<std::size_t>(memo->second)];
+                ctx.links.xsect_y_full[uj]   = shared.y_full;
+                ctx.links.xsect_a_full[uj]   = shared.a_full;
+                ctx.links.xsect_r_full[uj]   = shared.r_full;
+                ctx.links.xsect_w_max[uj]    = shared.w_max;
+                ctx.links.xsect_cheb_idx[uj] = memo->second;
+                continue;
+            }
+
+            const auto& tbl = ctx.tables.tables[static_cast<std::size_t>(ci)];
+            if (tbl.x.size() < 3) continue;   // too few points; a_full stays 0
+
+            // Scale the raw curve coordinates (bulge is a dimensionless
+            // angle ratio, tan(theta/4) — it does NOT scale).
+            std::vector<double> px(tbl.x.size()), py(tbl.y.size());
+            for (std::size_t i = 0; i < tbl.x.size(); ++i) {
+                px[i] = tbl.x[i] * scale;
+                py[i] = tbl.y[i] * scale;
+            }
+            const double* bulge_ptr = tbl.bulge.empty() ? nullptr : tbl.bulge.data();
+
+            std::vector<xsboundary::BElem> elems;
+            int rc = xsboundary::fromArcSpec(px.data(), py.data(), bulge_ptr,
+                                             static_cast<int>(px.size()), elems);
+            if (rc != 0) {
+                ctx.errors.push_back(format_error(ERR_CURVE_SEQUENCE, cname,
+                    "POLYGON boundary error " + std::to_string(rc)));
+                continue;
+            }
+
+            chebsec::ChebSection cs{};
+            rc = chebsec::compile(cs, elems.data(), static_cast<int>(elems.size()), is_open);
+            if (rc != 0) {
+                ctx.errors.push_back(format_error(ERR_CURVE_SEQUENCE, cname,
+                    "POLYGON compile error " + std::to_string(rc)));
+                continue;
+            }
+
+            const int cheb_idx = static_cast<int>(ctx.cheb_sections.size());
+            ctx.cheb_sections.push_back(cs);
+            ctx.cheb_boundaries.push_back(std::move(elems));
+
+            ctx.links.xsect_y_full[uj]   = cs.y_full;
+            ctx.links.xsect_a_full[uj]   = cs.a_full;
+            ctx.links.xsect_r_full[uj]   = cs.r_full;
+            ctx.links.xsect_w_max[uj]    = cs.w_max;
+            ctx.links.xsect_cheb_idx[uj] = cheb_idx;
+            polygon_memo.emplace(std::pair<int, double>{ci, scale}, cheb_idx);
+        }
+    }
+
     // Resolve STREET cross-sections — build a transect from each referenced
     // [STREETS] entry (gutter + road crown + backing) and attach it like an
     // IRREGULAR/CUSTOM table. Slopes are %→fraction and lengths display→ft,
@@ -1864,6 +1947,14 @@ void resolve_cross_references(SimulationContext& ctx) {
     // ORIFICE, WEIR). Orifice/weir flow equations use xsect_a_full, y_full,
     // and w_max from the [XSECTIONS] section — skipping them leaves a_full=0
     // which causes zero flow for all orifices.
+    //
+    // Under XSECT_GEOMETRY EXACT, a handful of self-contained shapes also get
+    // compiled to a Chebyshev boundary here (see LegacyShapeBoundary.hpp for
+    // which ones, and why the rest are left on LEGACY). Memoized by (batch
+    // shape, y_full, w_max) — the only inputs buildLegacyBoundary reads —
+    // so every link sharing a diameter/height shares one compiled section,
+    // same as the POLYGON and CUSTOM memoization above.
+    std::map<std::tuple<int, double, double>, int> legacy_exact_memo;
     for (int j = 0; j < n_links; ++j) {
         auto uj = static_cast<std::size_t>(j);
         auto lt = ctx.links.type[uj];
@@ -1895,6 +1986,29 @@ void resolve_cross_references(SimulationContext& ctx) {
                 a_full = xs.a_full; r_full = xs.r_full; w_max = xs.w_max;
                 s_full = xs.s_full; s_max = xs.s_max; yw_max = xs.yw_max;
                 ctx.links.xsect_a_bot[uj] = xs.a_bot;
+            }
+            break;
+        }
+
+        case XsectShape::POLYGON: {
+            // Properties already set from the compiled ChebSection above.
+            // Unlike CUSTOM's normalized curve, ChebSection carries s_full/
+            // s_max/yw_max directly — no separate y_full-scaling step needed.
+            a_full = ctx.links.xsect_a_full[uj];
+            r_full = ctx.links.xsect_r_full[uj];
+            w_max  = ctx.links.xsect_w_max[uj];
+            int ci = ctx.links.xsect_cheb_idx[uj];
+            if (ci >= 0 && static_cast<std::size_t>(ci) < ctx.cheb_sections.size()) {
+                const auto& cs = ctx.cheb_sections[static_cast<std::size_t>(ci)];
+                y_full = cs.y_full; a_full = cs.a_full; r_full = cs.r_full;
+                w_max  = cs.w_max;  s_full = cs.s_full; s_max  = cs.s_max;
+                yw_max = cs.yw_max;
+            } else {
+                // Not resolved (bad curve name, compile error, etc.) —
+                // fallback matches CUSTOM's own unresolved fallback.
+                s_full = a_full * std::pow(r_full, 2.0 / 3.0);
+                s_max  = s_full;
+                yw_max = y_full;
             }
             break;
         }
@@ -1971,6 +2085,35 @@ void resolve_cross_references(SimulationContext& ctx) {
                 ctx.links.xsect_a_bot[uj] = xs.a_bot;
                 ctx.links.xsect_s_bot[uj] = xs.s_bot;
                 ctx.links.xsect_r_bot[uj] = xs.r_bot;
+
+                if (ctx.options.xsect_geometry == XsectGeometryMode::EXACT) {
+                    const int batch_shape = xs.type;
+                    const auto key = std::tuple<int, double, double>{
+                        batch_shape, xs.y_full, xs.w_max};
+                    const auto memo = legacy_exact_memo.find(key);
+                    if (memo != legacy_exact_memo.end()) {
+                        ctx.links.xsect_cheb_idx[uj] = memo->second;
+                    } else {
+                        std::vector<xsboundary::BElem> elems;
+                        if (xsboundary::buildLegacyBoundary(
+                                static_cast<XSectShape>(batch_shape), xs, elems)) {
+                            chebsec::ChebSection cs{};
+                            const int crc = chebsec::compile(
+                                cs, elems.data(), static_cast<int>(elems.size()), false);
+                            if (crc == 0) {
+                                const int cheb_idx = static_cast<int>(ctx.cheb_sections.size());
+                                ctx.cheb_sections.push_back(cs);
+                                ctx.cheb_boundaries.push_back(std::move(elems));
+                                ctx.links.xsect_cheb_idx[uj] = cheb_idx;
+                                legacy_exact_memo.emplace(key, cheb_idx);
+                            }
+                            // compile() failure: EXACT is alpha/best-effort for
+                            // a shape LEGACY already evaluates correctly, so
+                            // silently keep the LEGACY path (xsect_cheb_idx
+                            // stays -1) rather than failing the whole model.
+                        }
+                    }
+                }
             } else {
                 // Invalid geometry — preserve the previous generic fallback.
                 a_full = w_max * y_full;

--- a/src/engine/input/handlers/LinksHandler.cpp
+++ b/src/engine/input/handlers/LinksHandler.cpp
@@ -317,6 +317,7 @@ static const std::unordered_map<std::string, XsectShape> SHAPE_MAP = {
     {"FORCE_MAIN",      XsectShape::FORCE_MAIN},
     {"STREET",          XsectShape::STREET_XSECT},
     {"DUMMY",           XsectShape::DUMMY},
+    {"POLYGON",         XsectShape::POLYGON},
 };
 
 void handle_xsections(SimulationContext& ctx, const std::vector<std::string>& lines) {
@@ -339,11 +340,25 @@ void handle_xsections(SimulationContext& ctx, const std::vector<std::string>& li
         auto it = SHAPE_MAP.find(shape_str);
         if (it != SHAPE_MAP.end()) {
             ctx.links.xsect_shape[idx] = it->second;
+        } else {
+            // A bad shape keyword used to fall through silently, leaving the
+            // link at its default-initialized CIRCULAR shape with Geom1-4
+            // still parsed as if they were a circular pipe's diameter/etc —
+            // e.g. a typo'd EGGSHAPED (correct keyword: EGG), or a nonsense
+            // keyword, both silently became a 2 ft circular pipe with no
+            // error and no warning. A bad [OPTIONS] keyword raises
+            // ERR_KEYWORD; a bad shape keyword must too.
+            ctx.errors.push_back(format_error(ERR_KEYWORD, shape_str));
+            continue;
         }
 
         // IRREGULAR shapes: tok[2] is transect name, not a dimension.
         // STREET shapes:    tok[2] is street name, not a dimension.
         // CUSTOM shapes:    tok[2] = y_full, tok[3] = shape curve name.
+        // POLYGON shapes:   tok[2] = scale, tok[3] = open-flag (both genuine
+        //                   numbers, captured by the raw Geom1-4 block below);
+        //                   curve name follows Barrels at tok[7], not tok[3]
+        //                   like CUSTOM, since tok[3] here is real geometry.
         // All need deferred resolution (TRANSECTS/STREETS/CURVES may not be
         // parsed yet).
         if (ctx.links.xsect_shape[idx] == XsectShape::IRREGULAR ||
@@ -358,13 +373,32 @@ void handle_xsections(SimulationContext& ctx, const std::vector<std::string>& li
                 ctx.links.pump_curve_name[idx] = tok[3]; // Shape curve name
                 ctx.links.xsect_curve[idx] = -1;
             }
+        } else if (ctx.links.xsect_shape[idx] == XsectShape::POLYGON) {
+            // y_full/w_max come from PostParseResolver's compile() of the
+            // boundary curve, not from these tokens — leave them at their
+            // zero default rather than transiently holding scale/open-flag.
+            if (tok.size() > 7) {
+                ctx.links.pump_curve_name[idx] = tok[7]; // Boundary curve name
+                ctx.links.xsect_cheb_idx[idx] = -1;
+            } else {
+                // A row short of tok[7] (e.g. Barrels omitted, which is
+                // optional for every other shape) leaves pump_curve_name
+                // empty; PostParseResolver's POLYGON block silently skips an
+                // empty curve name, so without this the link would fall
+                // through to a much later, harder-to-place "no usable
+                // cross-section" error instead of pointing at the actual
+                // malformed [XSECTIONS] row.
+                ctx.errors.push_back(format_error(ERR_ITEMS, tok[0]));
+                continue;
+            }
         } else {
             // Geom1 = full depth (diameter for circular, etc.)
             if (tok.size() > 2) ctx.links.xsect_y_full[idx] = to_double(tok[2]);
         }
 
-        // Geom2 = width or second parameter (shape-dependent, skip for CUSTOM)
-        if (ctx.links.xsect_shape[idx] != XsectShape::CUSTOM) {
+        // Geom2 = width or second parameter (shape-dependent, skip for CUSTOM/POLYGON)
+        if (ctx.links.xsect_shape[idx] != XsectShape::CUSTOM &&
+            ctx.links.xsect_shape[idx] != XsectShape::POLYGON) {
             if (tok.size() > 3) ctx.links.xsect_w_max[idx]  = to_double(tok[3]);
         }
 
@@ -396,8 +430,10 @@ void handle_xsections(SimulationContext& ctx, const std::vector<std::string>& li
                 ctx.link_subtypes.conduits.barrels[static_cast<std::size_t>(cr)] = barrels;
         }
 
-        // Culvert code (optional, token 7)
-        if (tok.size() > 7 && cr >= 0) {
+        // Culvert code (optional, token 7). Not for POLYGON — token 7 there
+        // is the boundary curve name, not a number.
+        if (tok.size() > 7 && cr >= 0 &&
+            ctx.links.xsect_shape[idx] != XsectShape::POLYGON) {
             int cc = static_cast<int>(to_double(tok[7]));
             if (cc > 0)
                 ctx.link_subtypes.conduits.culvert_code[static_cast<std::size_t>(cr)] = cc;

--- a/src/engine/input/handlers/OptionsHandler.cpp
+++ b/src/engine/input/handlers/OptionsHandler.cpp
@@ -479,6 +479,11 @@ void handle_options(SimulationContext& ctx, const std::vector<std::string>& line
             if      (nc == "EXPLICIT")      opt.node_continuity = NodeContinuity::EXPLICIT;
             else if (nc == "SEMI_IMPLICIT") opt.node_continuity = NodeContinuity::SEMI_IMPLICIT;
 
+        } else if (key == "XSECT_GEOMETRY") {
+            const std::string xg = norm(val);
+            if      (xg == "LEGACY") opt.xsect_geometry = XsectGeometryMode::LEGACY;
+            else if (xg == "EXACT")  opt.xsect_geometry = XsectGeometryMode::EXACT;
+
         } else if (key == "VIRTUAL_JUNCTION_MOMENTUM") {
             // RETIRED 2026-08-14. FULL is accepted and warned for one release,
             // then the keyword goes the way of FV_NODE_CELL_COUPLING above.

--- a/src/engine/input/handlers/TablesHandler.cpp
+++ b/src/engine/input/handlers/TablesHandler.cpp
@@ -56,6 +56,7 @@
 #include "../SectionParser.hpp"
 #include "../../core/SimulationContext.hpp"
 #include "../../core/DateTime.hpp"
+#include "../../core/ErrorCodes.hpp"
 #include "../../data/TableData.hpp"
 
 #include "../InputParseUtils.hpp"
@@ -221,6 +222,7 @@ static const std::unordered_map<std::string, TableType> CURVE_TYPE_MAP = {
     {"PUMP3",     TableType::CURVE_PUMP3},
     {"PUMP4",     TableType::CURVE_PUMP4},
     {"PUMP5",     TableType::CURVE_PUMP5},
+    {"XPOLYGON",  TableType::CURVE_XPOLYGON},
 };
 
 void handle_curves(SimulationContext& ctx, const std::vector<std::string>& lines) {
@@ -273,10 +275,49 @@ void handle_curves(SimulationContext& ctx, const std::vector<std::string>& lines
             }
         }
 
-        // Pairs: x y [x y ...]
-        for (std::size_t i = data_start; i + 1 < tok.size(); i += 2) {
-            tbl.x.push_back(to_double(tok[i]));
-            tbl.y.push_back(to_double(tok[i + 1]));
+        if (tbl.type == TableType::CURVE_XPOLYGON) {
+            // Variable column count per point: X Y [bulge] repeated. The
+            // stride (2 or 3) is decided ONCE for the whole curve, from the
+            // first data row's own token count, and then held fixed — NOT
+            // re-decided per row. A row-by-row modulo test would silently
+            // misparse a 6-token continuation row (divisible by both 2 and
+            // 3) as triples even when every sibling row in the same curve
+            // was pairs, scrambling every point after it with no error
+            // reported. First row's tie-break (a count divisible by BOTH):
+            // triples, since a genuinely bulge-free XPOLYGON curve may
+            // simply add an explicit 0.0 bulge column instead of omitting
+            // it. Every later row must fit the resolved stride exactly, or
+            // it is ragged (error 8, per XSectBoundary.hpp's
+            // BoundaryError::MALFORMED_CURVE_ROW).
+            const std::size_t n_tok = tok.size() - data_start;
+            if (tbl.xpolygon_stride == 0 && n_tok > 0) {
+                tbl.xpolygon_stride = (n_tok % 3 == 0) ? 3
+                                    : (n_tok % 2 == 0) ? 2
+                                    : 0;
+                if (tbl.xpolygon_stride == 0)
+                    ctx.errors.push_back(format_error(ERR_CURVE_SEQUENCE, current_name));
+            }
+            if (tbl.xpolygon_stride == 3 && n_tok % 3 == 0) {
+                for (std::size_t i = data_start; i + 2 < tok.size(); i += 3) {
+                    tbl.x.push_back(to_double(tok[i]));
+                    tbl.y.push_back(to_double(tok[i + 1]));
+                    tbl.bulge.push_back(to_double(tok[i + 2]));
+                }
+            } else if (tbl.xpolygon_stride == 2 && n_tok % 2 == 0) {
+                for (std::size_t i = data_start; i + 1 < tok.size(); i += 2) {
+                    tbl.x.push_back(to_double(tok[i]));
+                    tbl.y.push_back(to_double(tok[i + 1]));
+                    tbl.bulge.push_back(0.0);
+                }
+            } else if (n_tok > 0) {
+                ctx.errors.push_back(format_error(ERR_CURVE_SEQUENCE, current_name));
+            }
+        } else {
+            // Pairs: x y [x y ...]
+            for (std::size_t i = data_start; i + 1 < tok.size(); i += 2) {
+                tbl.x.push_back(to_double(tok[i]));
+                tbl.y.push_back(to_double(tok[i + 1]));
+            }
         }
     }
 }

--- a/src/engine/plugins/DefaultReportPlugin.cpp
+++ b/src/engine/plugins/DefaultReportPlugin.cpp
@@ -70,7 +70,7 @@ static const char* XsectShapeWords[] = {
     "CATENARY", "SEMI_ELLIPTIC", "BASKETHANDLE", "SEMI_CIRCULAR",
     "RECT_TRIANG", "RECT_ROUND", "HORIZ_ELLIPSE", "VERT_ELLIPSE",
     "ARCH", "IRREGULAR", "CUSTOM",
-    "FORCE_MAIN", "STREET", "DUMMY"
+    "FORCE_MAIN", "STREET", "DUMMY", "POLYGON"
 };
 
 // ---------------------------------------------------------------------------
@@ -484,7 +484,7 @@ void DefaultReportPlugin::write_preamble(std::FILE* f,
                 if (ctx.links.type[ui] != LinkType::CONDUIT) continue;
 
                 int shape = static_cast<int>(ctx.links.xsect_shape[ui]);
-                const char* shape_str = (shape >= 0 && shape <= 25) ?
+                const char* shape_str = (shape >= 0 && shape <= 26) ?
                     XsectShapeWords[shape] : "CIRCULAR";
 
                 const int cr = ctx.link_subtypes.conduit_row(i);
@@ -554,6 +554,10 @@ void DefaultReportPlugin::write_preamble(std::FILE* f,
                             : (rm == 1) ? "KINWAVE"
                                         : "STEADY";
         std::fprintf(f, "\n  Flow Routing Method ...... %s", rm_name);
+
+        const char* xg_name = (opt.xsect_geometry == XsectGeometryMode::EXACT)
+                              ? "EXACT" : "LEGACY";
+        std::fprintf(f, "\n  Cross-Section Geometry ... %s", xg_name);
 
         if (rm == 2) { // DYNWAVE
             int sm = opt.surcharge_method;

--- a/src/engine/transport/components/HeatFluxModules/RadiativeExchange.cpp
+++ b/src/engine/transport/components/HeatFluxModules/RadiativeExchange.cpp
@@ -36,6 +36,7 @@
 #include "SurfaceExchange.hpp"
 #include "../../../core/SimulationContext.hpp"
 #include "../../../core/UnitConversion.hpp"
+#include "../../../hydraulics/Link.hpp"
 #include "../../../hydraulics/Node.hpp"
 #include "../../../hydraulics/XSectBatch.hpp"
 
@@ -170,8 +171,11 @@ void applyRadiativeExchange(SimulationContext& ctx, double dt) {
         if (!(depth > 0.0)) continue;
 
         XSectParams xs{};
-        const auto ls = ctx.links.xsect_shape[uj];
-        xs.type   = (ls == XsectShape::DUMMY) ? 0 : static_cast<int>(ls) + 1;
+        // link::translateShape is the canonical LinkData-enum -> batch-enum
+        // translation (Link.cpp) — POLYGON=26 was appended to both enums at
+        // the same numeric value, breaking the flat +1 offset every earlier
+        // shape follows, so this delegates rather than re-deriving it here.
+        xs.type = link::translateShape(ctx.links.xsect_shape[uj]);
         xs.y_full = ctx.links.xsect_y_full[uj];
         xs.a_full = ctx.links.xsect_a_full[uj];
         xs.w_max  = ctx.links.xsect_w_max[uj];
@@ -182,6 +186,11 @@ void applyRadiativeExchange(SimulationContext& ctx, double dt) {
         xs.a_bot  = ctx.links.xsect_a_bot[uj];
         xs.s_bot  = ctx.links.xsect_s_bot[uj];
         xs.r_bot  = ctx.links.xsect_r_bot[uj];
+        {
+            const int ci = ctx.links.xsect_cheb_idx[uj];
+            if (ci >= 0 && static_cast<std::size_t>(ci) < ctx.cheb_sections.size())
+                xs.cheb = &ctx.cheb_sections[static_cast<std::size_t>(ci)];
+        }
         const double top_width = xsect::getWofY(xs, depth);
         if (!(top_width > 0.0)) continue;
 

--- a/src/engine/transport/components/HeatFluxModules/SurfaceExchange.cpp
+++ b/src/engine/transport/components/HeatFluxModules/SurfaceExchange.cpp
@@ -30,6 +30,7 @@
 
 #include "../../../core/SimulationContext.hpp"
 #include "../../../core/UnitConversion.hpp"
+#include "../../../hydraulics/Link.hpp"
 #include "../../../hydraulics/Node.hpp"
 #include "../../../hydraulics/XSectBatch.hpp"
 
@@ -40,10 +41,14 @@ namespace {
 /// Cross-section parameters for a link. Mirrors `Routing.cpp:54`'s local
 /// helper — the same one the non-DYNWAVE evaporation path uses, so an open
 /// conduit's exchange area is built exactly the way its evaporation area is.
-XSectParams buildXsp(const LinkData& links, std::size_t uk) {
+XSectParams buildXsp(const SimulationContext& ctx, std::size_t uk) {
+    const LinkData& links = ctx.links;
     XSectParams xs{};
-    const auto ls = links.xsect_shape[uk];
-    xs.type   = (ls == XsectShape::DUMMY) ? 0 : static_cast<int>(ls) + 1;
+    // link::translateShape is the canonical LinkData-enum -> batch-enum
+    // translation (Link.cpp) — POLYGON=26 was appended to both enums at the
+    // same numeric value, breaking the flat +1 offset every earlier shape
+    // follows, so this delegates rather than re-deriving the mapping here.
+    xs.type = link::translateShape(links.xsect_shape[uk]);
     xs.y_full = links.xsect_y_full[uk];
     xs.a_full = links.xsect_a_full[uk];
     xs.w_max  = links.xsect_w_max[uk];
@@ -54,6 +59,11 @@ XSectParams buildXsp(const LinkData& links, std::size_t uk) {
     xs.a_bot  = links.xsect_a_bot[uk];
     xs.s_bot  = links.xsect_s_bot[uk];
     xs.r_bot  = links.xsect_r_bot[uk];
+    {
+        const int ci = links.xsect_cheb_idx[uk];
+        if (ci >= 0 && static_cast<std::size_t>(ci) < ctx.cheb_sections.size())
+            xs.cheb = &ctx.cheb_sections[static_cast<std::size_t>(ci)];
+    }
     return xs;
 }
 
@@ -177,7 +187,7 @@ void applySurfaceExchange(SimulationContext& ctx, double dt) {
 
         const double depth = ctx.links.depth[uj];
         if (!(depth > 0.0)) continue;
-        const auto xs = buildXsp(ctx.links, uj);
+        const auto xs = buildXsp(ctx, uj);
         const double top_width = xsect::getWofY(xs, depth);
         if (!(top_width > 0.0)) continue;
         const double area_ft2 = top_width * length * CD.barrels[ucr];

--- a/tests/unit/engine/CMakeLists.txt
+++ b/tests/unit/engine/CMakeLists.txt
@@ -183,6 +183,13 @@ add_gtest_unit(test_engine_xsect_boundary    test_xsect_boundary.cpp)
 # the coordinate map, and the two trap-setters guarding the critical-height
 # split and the sqrt-end stretch.
 add_gtest_unit(test_engine_cheb_section      test_cheb_section.cpp)
+# Built-in shapes (CIRCULAR/FORCE_MAIN as a true circle; the 10 classic
+# tabulated shapes from their own width table) reconstructed as an exact
+# boundary under XSECT_GEOMETRY EXACT — see the file header for the real bug
+# this suite exists to catch (a silently-declining boundary construction is
+# indistinguishable from LEGACY at full depth, invisible without a partial-
+# depth check or a full-network run).
+add_gtest_unit(test_engine_legacy_shape_boundary test_legacy_shape_boundary.cpp)
 # GUI editor round-trip getters/setters (pollutant units, aquifer ET pattern,
 # snowpack surfaces, inlet params/type, LID layers/type).
 add_gtest_unit(test_engine_editor_roundtrip_api test_editor_roundtrip_api.cpp)

--- a/tests/unit/engine/test_legacy_shape_boundary.cpp
+++ b/tests/unit/engine/test_legacy_shape_boundary.cpp
@@ -1,0 +1,182 @@
+/**
+ * @file test_legacy_shape_boundary.cpp
+ * @brief LegacyShapeBoundary (Phase 5): built-in shapes reconstructed as an
+ *        exact arc/line boundary under `[OPTIONS] XSECT_GEOMETRY EXACT`.
+ *
+ * @details Exists because `buildLegacyBoundary()`'s failure mode is silent:
+ *          returning `false` just leaves a link on the ordinary LEGACY
+ *          table/formula path with no error, no warning, and (at full depth)
+ *          numerically plausible-looking scalars — `y_full`/`a_full`/
+ *          `r_full`/`w_max` for CIRCULAR come from setParams()'s closed-form
+ *          circle formulas either way, so a broken boundary construction is
+ *          invisible unless something specifically checks the return value
+ *          or queries a PARTIAL depth. That is exactly what happened here:
+ *          `buildCircle()` originally built a 2-point boundary (two
+ *          antipodal points, bulge=1 each), which `fromArcSpec()` rejects
+ *          outright (n >= 3 required) — so EXACT mode silently never
+ *          engaged for CIRCULAR/FORCE_MAIN at all until a full end-to-end
+ *          run on a real network (Bellinge, ~950 circular conduits) was
+ *          diffed against LEGACY and came back byte-identical, which is
+ *          what caught it. Every case here checks the return value AND a
+ *          partial-depth query against the same "is it actually different
+ *          from LEGACY, and by a sane amount" bar that full-scale test
+ *          would have applied immediately.
+ *
+ * @ingroup engine_hydraulics
+ */
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <vector>
+
+#include "hydraulics/ChebSection.hpp"
+#include "hydraulics/LegacyShapeBoundary.hpp"
+#include "hydraulics/XSectBatch.hpp"
+#include "hydraulics/XSectBoundary.hpp"
+#include "hydraulics/XSectKernels.hpp"
+
+using namespace openswmm;
+using openswmm::xsboundary::BElem;
+
+namespace {
+
+/// Build a LEGACY XSectParams for `shape` with geom[0..3], then attempt the
+/// EXACT boundary reconstruction and compile it. Returns whether
+/// buildLegacyBoundary() succeeded; on success, `exact_out` is `legacy`
+/// with `.cheb` pointing at `cs` (which the caller must keep alive).
+bool tryBuildExact(XSectShape shape, const double geom[4], XSectParams& legacy,
+                   chebsec::ChebSection& cs, XSectParams& exact_out) {
+    legacy = XSectParams{};
+    double p[4] = {geom[0], geom[1], geom[2], geom[3]};
+    xsect::setParams(legacy, static_cast<int>(shape), p, 1.0);
+
+    std::vector<BElem> elems;
+    if (!xsboundary::buildLegacyBoundary(shape, legacy, elems)) return false;
+
+    cs = chebsec::ChebSection{};
+    if (chebsec::compile(cs, elems.data(), static_cast<int>(elems.size()), false) != 0)
+        return false;
+
+    exact_out = legacy;
+    exact_out.cheb = &cs;
+    return true;
+}
+
+} // namespace
+
+// ===========================================================================
+// Every shape this module claims to support must actually build AND compile.
+// (TEST() macros below are deliberately outside the anonymous namespace
+// above, matching test_cheb_section.cpp's convention — only the helper
+// functions are namespace-local.)
+// ===========================================================================
+
+TEST(LegacyShapeBoundary, SupportedShapesAllBuildAndCompile) {
+    struct Case { XSectShape shape; double geom[4]; };
+    const Case cases[] = {
+        {XSectShape::CIRCULAR,       {2.0, 0, 0, 0}},
+        {XSectShape::FORCE_MAIN,     {2.0, 100.0, 0, 0}},
+        {XSectShape::EGGSHAPED,      {3.0, 0, 0, 0}},
+        {XSectShape::HORSESHOE,      {3.0, 0, 0, 0}},
+        {XSectShape::GOTHIC,         {3.0, 0, 0, 0}},
+        {XSectShape::CATENARY,       {3.0, 0, 0, 0}},
+        {XSectShape::SEMIELLIPTICAL, {3.0, 0, 0, 0}},
+        {XSectShape::BASKETHANDLE,   {3.0, 0, 0, 0}},
+        {XSectShape::SEMICIRCULAR,   {3.0, 0, 0, 0}},
+        {XSectShape::ARCH,           {3.0, 4.0, 0, 0}},
+        {XSectShape::HORIZ_ELLIPSE,  {2.0, 3.0, 0, 0}},
+        {XSectShape::VERT_ELLIPSE,   {3.0, 2.0, 0, 0}},
+    };
+    for (const auto& c : cases) {
+        XSectParams legacy, exact;
+        chebsec::ChebSection cs;
+        EXPECT_TRUE(tryBuildExact(c.shape, c.geom, legacy, cs, exact))
+            << "shape " << static_cast<int>(c.shape) << " should build+compile under EXACT";
+        EXPECT_GT(cs.n_pieces, 0);
+        EXPECT_GT(cs.y_full, 0.0);
+        EXPECT_GT(cs.a_full, 0.0);
+    }
+}
+
+// ===========================================================================
+// Shapes deliberately OUT of scope (already closed-form, no table error to
+// remove) must decline rather than silently doing nothing useful.
+// ===========================================================================
+
+TEST(LegacyShapeBoundary, OutOfScopeShapesDeclineRatherThanSilentlyNoOp) {
+    struct Case { XSectShape shape; double geom[4]; };
+    const Case cases[] = {
+        {XSectShape::RECT_CLOSED,  {2.0, 3.0, 0, 0}},
+        {XSectShape::RECT_OPEN,    {2.0, 3.0, 0, 0}},
+        {XSectShape::TRAPEZOIDAL,  {2.0, 1.0, 1.0, 1.0}},
+        {XSectShape::TRIANGULAR,   {2.0, 3.0, 0, 0}},
+        {XSectShape::PARABOLIC,    {2.0, 3.0, 0, 0}},
+        {XSectShape::POWERFUNC,    {2.0, 3.0, 2.0, 0}},
+        {XSectShape::FILLED_CIRCULAR, {4.0, 1.0, 0, 0}},
+    };
+    for (const auto& c : cases) {
+        XSectParams legacy, exact;
+        chebsec::ChebSection cs;
+        EXPECT_FALSE(tryBuildExact(c.shape, c.geom, legacy, cs, exact))
+            << "shape " << static_cast<int>(c.shape) << " has no table error to remove — "
+               "buildLegacyBoundary must decline, not silently succeed with nothing gained";
+    }
+}
+
+// ===========================================================================
+// The regression this file exists for: EXACT must produce a REAL, sane-sized
+// difference from LEGACY at a low-fill depth for CIRCULAR — the exact
+// scenario a 2-point (rejected) boundary made silently indistinguishable
+// from LEGACY doing nothing.
+// ===========================================================================
+
+TEST(LegacyShapeBoundary, CircularExactDivergesFromLegacyTableAtLowFill) {
+    const double geom[4] = {1.0, 0, 0, 0};
+    XSectParams legacy, exact;
+    chebsec::ChebSection cs;
+    ASSERT_TRUE(tryBuildExact(XSectShape::CIRCULAR, geom, legacy, cs, exact));
+
+    // At y/D = 0.02, legacy's 26-point table is documented (Phase 4 design
+    // notes) to carry ~1.3% true error on CIRCULAR specifically — small
+    // compared to other shapes, but not zero, and NOT what "two different
+    // code paths returning the identical float" looks like.
+    const double y = 0.02 * legacy.y_full;
+    const double aL = xsect::getAofY(legacy, y);
+    const double aE = xsect::getAofY(exact, y);
+    ASSERT_GT(aL, 0.0);
+    const double rel_diff = std::fabs(aL - aE) / aL;
+
+    EXPECT_GT(rel_diff, 1.0e-4)
+        << "legacy=" << aL << " exact=" << aE << " — EXACT must be measurably "
+           "different from LEGACY here, or it silently is not engaging";
+    // But not absurdly different either — both describe the same physical
+    // pipe, so this is a bound against a sign error or unit mixup, not a
+    // tight accuracy assertion (that belongs in test_cheb_section.cpp).
+    EXPECT_LT(rel_diff, 0.5);
+
+    // Full-depth scalars come from setParams()'s closed-form circle formula
+    // in BOTH modes (this is exactly why the original bug was invisible at
+    // full depth) — confirm they still agree, so this test cannot be
+    // satisfied by an EXACT path that is merely wrong instead of engaged.
+    EXPECT_NEAR(exact.a_full, legacy.a_full, 1.0e-9);
+    EXPECT_NEAR(exact.r_full, legacy.r_full, 1.0e-9);
+}
+
+TEST(LegacyShapeBoundary, GothicExactDivergesFromLegacyTable) {
+    const double geom[4] = {4.0, 0, 0, 0};
+    XSectParams legacy, exact;
+    chebsec::ChebSection cs;
+    ASSERT_TRUE(tryBuildExact(XSectShape::GOTHIC, geom, legacy, cs, exact));
+
+    // GOTHIC's own width/area tables are documented (Phase 4 closeout) to
+    // disagree with each other by up to 439% near the invert — pick a depth
+    // comfortably inside that regime.
+    const double y = 0.05 * legacy.y_full;
+    const double wL = xsect::getWofY(legacy, y);
+    const double wE = xsect::getWofY(exact, y);
+    ASSERT_GT(wL, 0.0);
+    const double rel_diff = std::fabs(wL - wE) / wL;
+    EXPECT_GT(rel_diff, 1.0e-3)
+        << "legacy=" << wL << " exact=" << wE;
+}

--- a/tests/unit/engine/test_xsect_api.cpp
+++ b/tests/unit/engine/test_xsect_api.cpp
@@ -151,8 +151,10 @@ TEST(XSectShapeEnumParity, ShapeNameRejectsOutOfRange)
 {
     EXPECT_STREQ(swmm_xsect_shape_name(SWMM_XSECT_CIRCULAR), "CIRCULAR");
     EXPECT_STREQ(swmm_xsect_shape_name(SWMM_XSECT_IRREGULAR), "IRREGULAR");
+    // POLYGON=26 (Phase 5) extended the valid range by one.
+    EXPECT_STREQ(swmm_xsect_shape_name(SWMM_XSECT_POLYGON), "POLYGON");
     EXPECT_EQ(swmm_xsect_shape_name(-1), nullptr);
-    EXPECT_EQ(swmm_xsect_shape_name(26), nullptr);
+    EXPECT_EQ(swmm_xsect_shape_name(27), nullptr);
 }
 
 // ===========================================================================


### PR DESCRIPTION
…dispatch

Adds a POLYGON cross-section shape end to end: an arc/line boundary curve ([CURVES] XPOLYGON, DXF bulge convention) compiled via ChebSection::compile() and dispatched through every XsectEval accessor (getAofY/getWofY/getRofY/ getYofA/getRofA/getSofA/getdSdA/getAofS/getAmax/getYcrit/isOpen) ahead of the legacy xs.type switch whenever XSectParams::cheb is set.

Also adds [OPTIONS] XSECT_GEOMETRY LEGACY|EXACT (default LEGACY). Under EXACT, every shape whose legacy path is a lossy interpolated table — not just POLYGON — gets a compiled boundary too: CIRCULAR/FORCE_MAIN as a true 4-arc circle, and EGG/HORSESHOE/GOTHIC/CATENARY/SEMIELLIPTICAL/BASKETHANDLE/ SEMICIRCULAR/ARCH/HORIZ_ELLIPSE/VERT_ELLIPSE reconstructed as a polyline from each shape's own existing width table (new LegacyShapeBoundary.{hpp,cpp}). Shapes with closed-form legacy formulas (RECT_CLOSED, TRAPEZOIDAL, etc.) are deliberately left alone — EXACT has no interpolation error to remove there. FILLED_CIRCULAR is a documented, explicit gap (needs a circular-segment construction not yet written); LEGACY mode is provably unaffected (xs.cheb stays null — full ctest suite identical before/after via git stash).

Bugs found and fixed along the way:
- ChebSection::compile() (already-merged Phase 4 code) computed wetted perimeter by extrapolating the fitted series to y_full, which is wrong for any flat/cornered crown (P has a real physical jump there — dry above, pressurized-full at — that a round crown's series happens not to have, which is why circle-only test coverage never caught it). Added ChebSection::p_full, the true closed-loop perimeter, read directly instead of re-derived at every call site.
- An unrecognized [XSECTIONS] shape keyword silently fell back to CIRCULAR with no warning; same bug independently in DefaultReportPlugin's shape-name lookup. Both now raise/report correctly instead of masking the typo.
- 6 files each hand-rolled the same "LinkData enum -> batch enum" +1-offset translation, broken by POLYGON landing on the same numeric value in both enums; all fixed and, since found once, all 6 sites consolidated onto the single existing link::translateShape (plus a 7th, independent duplicate removed from Router::init).

A `/code-review` pass on the full diff, followed by validation against the real Bellinge network (953 conduits, LEGACY vs EXACT), found and fixed six more issues:
- CRITICAL: XSectBatch.cpp's batch kernels (apply_area_kernel/ apply_hydrad_kernel/apply_width_kernel/apply_area_hydrad_kernel) had explicit CIRCULAR/FORCE_MAIN fast paths that never checked xs.cheb, so EXACT mode silently never engaged for CIRCULAR conduits — the dominant shape in most networks — in the DYNWAVE hot loop. This was the mechanism behind an anomalously small LEGACY-vs-EXACT difference on Bellinge that looked like agreement but was actually the bug. Fixed per-element (a group can have a mix of compiled/uncompiled links).
- NetworkMeshBuilder's FV geometry memoization key didn't hash xs.cheb, so two links with identical scalar summaries but different compiled boundaries could alias and silently share the wrong tabulated geometry.
- POLYGON's open/closed classification was wrong at the root (DynamicWave's is_open_ precompute, read in ~10 places) rather than just at the one call site initially flagged — fixed there so every downstream reader is correct at once.
- TablesHandler's XPOLYGON parser decided its column stride (pairs vs. bulge triples) independently per row, which could silently misparse a 6-token continuation row; now resolved once per curve and held fixed.
- A POLYGON [XSECTIONS] row missing its curve name (e.g. Barrels omitted) now raises a clear error immediately instead of surfacing much later as a generic zero-geometry failure.

routing CIRCULAR conduits through the same per-element Chebyshev path as POLYGON, instead of the vectorized legacy table kernel, measured ~4.3x slower network-wide on Bellinge, but there are more complex approaches to accomplish more speed. Mitigated one redundant-evaluation source (chebAll's single shared-basis pass instead of getRofY/chebRofY independently re-walking the same piece for area and again for perimeter), cutting the gap from ~5.1x to ~4.3x, verified numerically inert against the pre-optimization run. Closing the remainder needs a genuine SIMD gather kernel — deferred, since EXACT is alpha-gated/opt-in and LEGACY (default) is unaffected.

Verification: full ctest suite (131/134 — the 3 non-passes are pre-existing, confirmed-unrelated ulp noise and a 2D-surface linker gap needing a separate build flag), a new 4-test LegacyShapeBoundary regression suite, and an end-to-end LEGACY-vs-EXACT run of the Bellinge network (continuity error small and comparable in both modes; node-inflow differences consistent with EXACT now genuinely engaging the whole network).